### PR TITLE
Unbox Bytes.t or Bigstring.t on decompress

### DIFF
--- a/lib/decompress.ml
+++ b/lib/decompress.ml
@@ -1,6 +1,6 @@
-module B       = Decompress_impl.B
-module Hunk    = Decompress_impl.Hunk
-module L       = Decompress_impl.L
+module B = Decompress_impl.B
+module Hunk = Decompress_impl.Hunk
+module L = Decompress_impl.L
 
 module type DEFLATE =
 sig
@@ -27,7 +27,7 @@ sig
   val flush_of_meth: meth -> (int -> int -> ('x, 'x) t -> ('x, 'x) t)
   val flush: int -> int -> ('i, 'o) t -> ('i, 'o) t
 
-  val eval: 'a B.t -> 'a B.t -> ('a, 'a) t ->
+  val eval: 'a -> 'a -> ('a, 'a) t ->
     [ `Await of ('a, 'a) t
     | `Flush of ('a, 'a) t
     | `End   of ('a, 'a) t
@@ -36,20 +36,20 @@ sig
   val used_in: ('i, 'o) t -> int
   val used_out: ('i, 'o) t -> int
 
-  val default: proof:'o B.t -> ?wbits:int -> int -> ('i, 'o) t
+  val default: witness:'a B.t -> ?wbits:int -> int -> ('a, 'a) t
 
-  val to_result: 'a B.t -> 'a B.t -> ?meth:(meth * int) ->
-                 ('a B.t -> int option -> int) ->
-                 ('a B.t -> int -> int) ->
+  val to_result: 'a -> 'a -> ?meth:(meth * int) ->
+                 ('a -> int option -> int) ->
+                 ('a -> int -> int) ->
                  ('a, 'a) t -> (('a, 'a) t, error) result
   val bytes: Bytes.t -> Bytes.t -> ?meth:(meth * int) ->
              (Bytes.t -> int option -> int) ->
              (Bytes.t -> int -> int) ->
-             (B.st, B.st) t -> ((B.st, B.st) t, error) result
+             (Bytes.t, Bytes.t) t -> ((Bytes.t, Bytes.t) t, error) result
   val bigstring: B.Bigstring.t -> B.Bigstring.t -> ?meth:(meth * int) ->
                  (B.Bigstring.t -> int option -> int) ->
                  (B.Bigstring.t -> int -> int) ->
-                 (B.bs, B.bs) t -> ((B.bs, B.bs) t, error) result
+                 (B.Bigstring.t, B.Bigstring.t) t -> ((B.Bigstring.t, B.Bigstring.t) t, error) result
 end
 
 type error_rfc1951_deflate = Decompress_impl.error_rfc1951_deflate = Lz77 of L.error
@@ -71,7 +71,7 @@ sig
   val pp_error: Format.formatter -> error -> unit
   val pp: Format.formatter -> ('i, 'o) t -> unit
 
-  val eval: 'a B.t -> 'a B.t -> ('a, 'a) t ->
+  val eval: 'a -> 'a -> ('a, 'a) t ->
     [ `Await of ('a, 'a) t
     | `Flush of ('a, 'a) t
     | `End   of ('a, 'a) t
@@ -84,20 +84,20 @@ sig
   val used_out: ('i, 'o) t -> int
   val write: ('i, 'o) t -> int
 
-  val default: 'o Window.t -> ('i, 'o) t
+  val default: witness:'a B.t -> 'a Window.t -> ('a, 'a) t
 
-  val to_result: 'a B.t -> 'a B.t ->
-                 ('a B.t -> int) ->
-                 ('a B.t -> int -> int) ->
+  val to_result: 'a -> 'a ->
+                 ('a -> int) ->
+                 ('a -> int -> int) ->
                  ('a, 'a) t -> (('a, 'a) t, error) result
   val bytes: Bytes.t -> Bytes.t ->
              (Bytes.t -> int) ->
              (Bytes.t -> int -> int) ->
-             (B.st, B.st) t -> ((B.st, B.st) t, error) result
+             (Bytes.t, Bytes.t) t -> ((Bytes.t, Bytes.t) t, error) result
   val bigstring: B.Bigstring.t -> B.Bigstring.t ->
                  (B.Bigstring.t -> int) ->
                  (B.Bigstring.t -> int -> int) ->
-                 (B.bs, B.bs) t -> ((B.bs, B.bs) t, error) result
+                 (B.Bigstring.t, B.Bigstring.t) t -> ((B.Bigstring.t, B.Bigstring.t) t, error) result
 end
 
 type error_rfc1951_inflate = Decompress_impl.error_rfc1951_inflate =

--- a/lib/decompress.mli
+++ b/lib/decompress.mli
@@ -1,62 +1,14 @@
 module B:
 sig
-  type st = St
-  type bs = Bs
-
   module Bigstring:
-  sig
-    open Bigarray
-
-    type t = (char, int8_unsigned_elt, c_layout) Array1.t
-
-    val length: t -> int
-    val create: int -> t
-    val get: t -> int -> char
-    val set: t -> int -> char -> unit
-    val sub: t -> int -> int -> t
-    val fill: t -> char -> unit
-    val copy: t -> t
-    val get_u16: t -> int -> int
-    val get_u32: t -> int -> int32
-    val get_u64: t -> int -> int64
-    val set_u16: t -> int -> int -> unit
-    val set_u32: t -> int -> int32 -> unit
-    val set_u64: t -> int -> int64 -> unit
-    val to_string: t -> string
-    val blit: t -> int -> t -> int -> int -> unit
-    val pp: Format.formatter -> t -> unit
-    val empty: t
-  end
+  sig type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t end
 
   type 'a t =
-    | Bytes     : Bytes.t -> st t
-    | Bigstring : Bigstring.t -> bs t
+    | Bytes : Bytes.t t
+    | Bigstring : Bigstring.t t
 
-  val from_bytes: Bytes.t -> st t
-  val from_bigstring: Bigstring.t -> bs t
-  val from: proof: 'a t -> int -> 'a t
-
-  val length: 'a t -> int
-  val get: 'a t -> int -> char
-  val set: 'a t -> int -> char -> unit
-
-  val get_u16: 'a t -> int -> int
-  val get_u32: 'a t -> int -> int32
-  val get_u64: 'a t -> int -> int64
-  val set_u16: 'a t -> int -> int -> unit
-  val set_u32: 'a t -> int -> int32 -> unit
-  val set_u64: 'a t -> int -> int64 -> unit
-
-  val to_string: 'a t -> string
-
-  val blit: 'a t -> int -> 'a t -> int -> int -> unit
-  val sub: 'a t -> int -> int -> 'a t
-  val fill: 'a t -> int -> int -> char -> unit
-  val pp: Format.formatter -> 'a t -> unit
-  val empty: proof:'a t -> 'a t
-
-  val proof_bytes: st t
-  val proof_bigstring: bs t
+  val bytes: Bytes.t t
+  val bigstring: Bigstring.t t
 end
 
 (** Decompress, functionnal implementation of Zlib in OCaml. *)
@@ -131,7 +83,7 @@ sig
       [on] is a function to interact fastly with your data-structure and keep
       the frequencies of the [Literal] and [Match].
   *)
-  val default  : ?level:int -> ?on:(Hunk.t -> unit) -> int -> 'i t
+  val default  : witness:'i B.t -> ?level:int -> ?on:(Hunk.t -> unit) -> int -> 'i t
 end
 
 (** Deflate algorithm.
@@ -229,7 +181,7 @@ sig
         be [t] writes something in your output. You can check with {!used_out}.
       - [`Error (t, exn)]: the algorithm catches an error [exn].
    *)
-  val eval            : 'a B.t -> 'a B.t -> ('a, 'a) t ->
+  val eval            : 'a -> 'a -> ('a, 'a) t ->
     [ `Await of ('a, 'a) t
     | `Flush of ('a, 'a) t
     | `End   of ('a, 'a) t
@@ -257,7 +209,7 @@ sig
       - 4 .. 9: a dynamic compression (compression with a canonic huffman tree
                 produced by the input)
    *)
-  val default         : proof:'o B.t -> ?wbits:int -> int -> ('i, 'o) t
+  val default         : witness:'a B.t -> ?wbits:int -> int -> ('a, 'a) t
 
   (** [to_result i o refill flush t] is a convenience function to apply the
       deflate algorithm on the stream [refill] and call [flush] when the
@@ -266,22 +218,22 @@ sig
       If the compute catch an error, we returns [Error exn]
       (see {!DEFLATE.error}). Otherwise, we returns the {i useless} state [t].
    *)
-  val to_result : 'a B.t -> 'a B.t -> ?meth:(meth * int) ->
-                  ('a B.t -> int option -> int) ->
-                  ('a B.t -> int -> int) ->
+  val to_result : 'a -> 'a -> ?meth:(meth * int) ->
+                  ('a -> int option -> int) ->
+                  ('a -> int -> int) ->
                   ('a, 'a) t -> (('a, 'a) t, error) result
 
   (** Specialization of {!to_result} with {!B.Bytes.t}. *)
   val bytes     : Bytes.t -> Bytes.t -> ?meth:(meth * int) ->
                   (Bytes.t -> int option -> int) ->
                   (Bytes.t -> int -> int) ->
-                  (B.st, B.st) t -> ((B.st, B.st) t, error) result
+                  (Bytes.t, Bytes.t) t -> ((Bytes.t, Bytes.t) t, error) result
 
   (** Specialization of {!to_result} with {!B.Bigstring.t}. *)
   val bigstring : B.Bigstring.t -> B.Bigstring.t -> ?meth:(meth * int) ->
                   (B.Bigstring.t -> int option -> int) ->
                   (B.Bigstring.t -> int -> int) ->
-                  (B.bs, B.bs) t -> ((B.bs, B.bs) t, error) result
+                  (B.Bigstring.t, B.Bigstring.t) t -> ((B.Bigstring.t, B.Bigstring.t) t, error) result
 end
 
 type error_rfc1951_deflate = Lz77 of L.error
@@ -309,7 +261,7 @@ sig
   type 'o t
 
   (** [create ~proof] creates a new window. *)
-  val create: proof:'o B.t -> 'o t
+  val create: witness:'o B.t -> 'o t
 
   (** [reset window] resets a window to be reused by an Inflate algorithm. *)
   val reset: 'o t -> 'o t
@@ -348,7 +300,7 @@ sig
       {- [`End t]: means that the deflate algorithm is done in your input. May
      be [t] writes something in your output. You can check with {!used_out}.}
       {- [`Error (t, exn)]: the algorithm catches an error [exn].}} *)
-  val eval: 'a B.t -> 'a B.t -> ('a, 'a) t ->
+  val eval: 'a -> 'a -> ('a, 'a) t ->
     [ `Await of ('a, 'a) t
     | `Flush of ('a, 'a) t
     | `End   of ('a, 'a) t
@@ -372,7 +324,7 @@ sig
   val write: ('i, 'o) t -> int
 
   (** [default] makes a new state [t]. *)
-  val default: 'o Window.t -> ('i, 'o) t
+  val default: witness:'a B.t -> 'a Window.t -> ('a, 'a) t
 
   (** [to_result i o refill flush t] is a convenience function to apply the
      inflate algorithm on the stream [refill] and call [flush] when the internal
@@ -381,9 +333,9 @@ sig
       If the compute catch an error, we returns [Error exn] (see
      {!INFLATE.error}). Otherwise, we returns the state {i useless} [t]. *)
   val to_result:
-    'a B.t -> 'a B.t ->
-    ('a B.t -> int) ->
-    ('a B.t -> int -> int) ->
+    'a -> 'a ->
+    ('a -> int) ->
+    ('a -> int -> int) ->
     ('a, 'a) t -> (('a, 'a) t, error) result
 
   (** Specialization of {!to_result} with {!B.Bytes.t}. *)
@@ -391,14 +343,14 @@ sig
     Bytes.t -> Bytes.t ->
     (Bytes.t -> int) ->
     (Bytes.t -> int -> int) ->
-    (B.st, B.st) t -> ((B.st, B.st) t, error) result
+    (Bytes.t, Bytes.t) t -> ((Bytes.t, Bytes.t) t, error) result
 
   (** Specialization of {!to_result} with {!B.Bigstring.t}. *)
   val bigstring:
     B.Bigstring.t -> B.Bigstring.t ->
     (B.Bigstring.t -> int) ->
     (B.Bigstring.t -> int -> int) ->
-    (B.bs, B.bs) t -> ((B.bs, B.bs) t, error) result
+    (B.Bigstring.t, B.Bigstring.t) t -> ((B.Bigstring.t, B.Bigstring.t) t, error) result
 end
 
 type error_rfc1951_inflate =

--- a/lib/decompress_b.ml
+++ b/lib/decompress_b.ml
@@ -1,330 +1,111 @@
-module Bigstring =
-struct
-  open Bigarray
-
-  type t = (char, int8_unsigned_elt, c_layout) Array1.t
-
-  let length = Array1.dim
-  let create = Array1.create Char c_layout
-  let get    = Array1.get
-  let set    = Array1.set
-  let sub    = Array1.sub
-  let fill   = Array1.fill
-  let copy v =
-    let v' = create (length v) in
-    Array1.blit v v'; v'
-
-  external get_u16 : t -> int -> int     = "%caml_bigstring_get16u"
-
-  let get_u16 t i =
-    if i < 0 || i > length t - 2
-    then raise (Invalid_argument "Bytes.get_u16")
-    else get_u16 t i
-
-  external get_u32 : t -> int -> Int32.t = "%caml_bigstring_get32u"
-
-  let get_u32 t i =
-    if i < 0 || i > length t - 4
-    then raise (Invalid_argument "Bytes.get_u32")
-    else get_u32 t i
-
-  external get_u64 : t -> int -> Int64.t = "%caml_bigstring_get64u"
-
-  let get_u64 t i =
-    if i < 0 || i > length t - 8
-    then raise (Invalid_argument "Bytes.get_u64")
-    else get_u64 t i
-
-  external set_u16 : t -> int -> int -> unit     = "%caml_bigstring_set16u"
-
-  let set_u16 t i =
-    if i < 0 || i > length t - 2
-    then raise (Invalid_argument "Bytes.set_u16")
-    else set_u16 t i
-
-  external set_u32 : t -> int -> Int32.t -> unit = "%caml_bigstring_set32u"
-
-  let set_u32 t i =
-    if i < 0 || i > length t - 4
-    then raise (Invalid_argument "Bytes.set_u32")
-    else set_u32 t i
-
-  external set_u64 : t -> int -> Int64.t -> unit = "%caml_bigstring_set64u"
-
-  let set_u64 t i =
-    if i < 0 || i > length t - 8
-    then raise (Invalid_argument "Bytes.set_u64")
-    else set_u64 t i
-
-  let to_string v =
-    let buf = Bytes.create (length v) in
-    for i = 0 to length v - 1
-    do Bytes.set buf i (get v i) done;
-    Bytes.unsafe_to_string buf
-
-  (* XXX: memcpy instead memmove *)
-  let blit src src_off dst dst_off len =
-    for i = 0 to len - 1
-    do set dst (dst_off + i) (get src (src_off + i)) done
-
-  let blit src src_off dst dst_off len =
-    if len < 0 || src_off < 0 || src_off > length src - len
-               || dst_off < 0 || dst_off > length dst - len
-    then raise (Invalid_argument (Format.sprintf "Bigstring.blit (src: %d:%d, \
-                                                                  dst: %d:%d, \
-                                                                  len: %d)"
-                                    src_off (length src)
-                                    dst_off (length dst)
-                                    len))
-    else blit src src_off dst dst_off len
-
-  let blit2 src src_off dst0 dst_off0 dst1 dst_off1 len =
-    if len < 0 || src_off < 0  || src_off > length src - len
-               || dst_off0 < 0 || dst_off0 > length dst0 - len
-               || dst_off1 < 0 || dst_off1 > length dst1 - len
-    then raise (Invalid_argument (Format.sprintf "Bigstring.blit2 (src: %d:%d, \
-                                                                   dst0: %d:%d, \
-                                                                   dst1 %d:%d, \
-                                                                   len: %d)"
-                                    src_off (length src)
-                                    dst_off0 (length dst0)
-                                    dst_off1 (length dst1)
-                                    len))
-    else for i = 0 to len - 1
-      do
-        set dst0 (dst_off0 + i) (get src (src_off + i));
-        set dst1 (dst_off1 + i) (get src (src_off + i));
-      done
-
-  let pp fmt ba =
-    for i = 0 to length ba - 1
-    do Format.pp_print_char fmt (get ba i) done
-
-  let empty = create 0
-end
-
-
-module Bytes =
-struct
-  include Bytes
-
-  external get_u16 : t -> int -> int     = "%caml_string_get16u"
-
-  let get_u16 t i =
-    if i < 0 || i > length t - 2
-    then raise (Invalid_argument "Bytes.get_u16")
-    else get_u16 t i
-
-  external get_u32 : t -> int -> Int32.t = "%caml_string_get32u"
-
-  let get_u32 t i =
-    if i < 0 || i > length t - 4
-    then raise (Invalid_argument "Bytes.get_u32")
-    else get_u32 t i
-
-  external get_u64 : t -> int -> Int64.t = "%caml_string_get64u"
-
-  let get_u64 t i =
-    if i < 0 || i > length t - 8
-    then raise (Invalid_argument "Bytes.get_u64")
-    else get_u64 t i
-
-  external set_u16 : t -> int -> int -> unit     = "%caml_string_set16u"
-
-  let set_u16 t i =
-    if i < 0 || i > length t - 2
-    then raise (Invalid_argument "Bytes.set_u16")
-    else set_u16 t i
-
-  external set_u32 : t -> int -> Int32.t -> unit = "%caml_string_set32u"
-
-  let set_u32 t i =
-    if i < 0 || i > length t - 4
-    then raise (Invalid_argument "Bytes.set_u32")
-    else set_u32 t i
-
-  external set_u64 : t -> int -> Int64.t -> unit = "%caml_string_set64u"
-
-  let set_u64 t i =
-    if i < 0 || i > length t - 8
-    then raise (Invalid_argument "Bytes.set_u64")
-    else set_u64 t i
-
-  let pp fmt bs =
-    for i = 0 to length bs - 1
-    do Format.pp_print_char fmt (get bs i) done
-
-  (* XXX: memcpy instead memmove *)
-  let blit src src_off dst dst_off len =
-    for i = 0 to len - 1
-    do set dst (dst_off + i) (get src (src_off + i)) done
-
-  let blit src src_off dst dst_off len =
-    if len < 0 || src_off < 0 || src_off > length src - len
-               || dst_off < 0 || dst_off > length dst - len
-    then raise (Invalid_argument (Format.sprintf "Bytes.blit (src: %d:%d, \
-                                                              dst: %d:%d, \
-                                                              len: %d)"
-                                    src_off (length src)
-                                    dst_off (length dst)
-                                    len))
-    else blit src src_off dst dst_off len
-
-  (* XXX(dinosaure): Consider than [src] and [dst] it's the same buffer (the window).
-                     We need to use the [blit2] function when we have a match. Indeed,
-                     previously, we have to case:
-
-                     * update the window, then update the dst
-
-                       This is wrong because for a large distance we write on
-                       the old bytes of the window and but these old bytes are
-                       not yet saved in the output.
-
-                     * update the dst, then update the output
-
-                       This is wrong too because may be you need the new bytes
-                       of the window (for a short distance or close to the write
-                       position of the window) and [blit] unbehaviour bytes to
-                       dst.
-
-                     So, per byte, we update firstly the window and, then the output.
-
-   *)
-  let blit2 src src_off dst0 dst_off0 dst1 dst_off1 len =
-    if len < 0 || src_off < 0  || src_off > length src - len
-               || dst_off0 < 0 || dst_off0 > length dst0 - len
-               || dst_off1 < 0 || dst_off1 > length dst1 - len
-    then raise (Invalid_argument (Format.sprintf "Bytes.blit2 (src: %d:%d, \
-                                                               dst0: %d:%d, \
-                                                               dst1 %d:%d, \
-                                                               len: %d)"
-                                    src_off (length src)
-                                    dst_off0 (length dst0)
-                                    dst_off1 (length dst1)
-                                    len))
-    else for i = 0 to len - 1
-      do
-        set dst0 (dst_off0 + i) (get src (src_off + i)); (* write the character in the window *)
-        set dst1 (dst_off1 + i) (get src (src_off + i)); (* write the character in the output *)
-      done
-end
-
-(* mandatory for a GADT *)
-type st = St
-type bs = Bs
+module Bigstring = Decompress_bigstring
+module Bytes = Decompress_bytes
 
 type 'a t =
-  | Bytes : Bytes.t -> st t
-  | Bigstring : Bigstring.t -> bs t
+  | Bytes : Bytes.t t
+  | Bigstring : Bigstring.t t
 
-let from_bytes v = Bytes v
-let from_bigstring v = Bigstring v
+let bytes = Bytes
+let bigstring = Bigstring
 
-let from
-  : type a. proof:a t -> int -> a t
-  = fun ~proof len -> match proof with
-  | Bytes _ -> Bytes (Bytes.create len)
-  | Bigstring _ -> Bigstring (Bigstring.create len)
+let create
+  : type a. a t -> int -> a
+  = function
+    | Bytes -> Bytes.create
+    | Bigstring -> Bigstring.create
 
 let length
-  : type a. a t -> int
+  : type a. a t -> a -> int
   = function
-  | Bytes v -> Bytes.length v
-  | Bigstring v -> Bigstring.length v
+  | Bytes -> Bytes.length
+  | Bigstring -> Bigstring.length
 
 let get
-  : type a. a t -> int -> char
-  = fun v idx -> match v with
-  | Bytes v -> Bytes.get v idx
-  | Bigstring v -> Bigstring.get v idx
+  : type a. a t -> a -> int -> char
+  = function
+  | Bytes -> Bytes.get
+  | Bigstring -> Bigstring.get
 
 let set
-  : type a. a t -> int -> char -> unit
-  = fun v idx chr -> match v with
-  | Bytes v -> Bytes.set v idx chr
-  | Bigstring v -> Bigstring.set v idx chr
+  : type a. a t -> a -> int -> char -> unit
+  = function
+  | Bytes -> Bytes.set
+  | Bigstring -> Bigstring.set
 
-let get_u16
-  : type a. a t -> int -> int
-  = fun v idx -> match v with
-  | Bytes v -> Bytes.get_u16 v idx
-  | Bigstring v -> Bigstring.get_u16 v idx
+let get_16
+  : type a. a t -> a -> int -> int
+  = function
+  | Bytes -> Bytes.get_16
+  | Bigstring -> Bigstring.get_16
 
-let get_u32
-  : type a. a t -> int -> Int32.t
-  = fun v idx -> match v with
-  | Bytes v -> Bytes.get_u32 v idx
-  | Bigstring v -> Bigstring.get_u32 v idx
+let get_32
+  : type a. a t -> a -> int -> int32
+  = function
+  | Bytes -> Bytes.get_32
+  | Bigstring -> Bigstring.get_32
 
-let get_u64
-  : type a. a t -> int -> Int64.t
-  = fun v idx -> match v with
-  | Bytes v -> Bytes.get_u64 v idx
-  | Bigstring v -> Bigstring.get_u64 v idx
+let get_64
+  : type a. a t -> a -> int -> int64
+  = function
+  | Bytes -> Bytes.get_64
+  | Bigstring -> Bigstring.get_64
 
-let set_u16
-  : type a. a t -> int -> int -> unit
-  = fun v idx u -> match v with
-  | Bytes v -> Bytes.set_u16 v idx u
-  | Bigstring v -> Bigstring.set_u16 v idx u
+let set_16
+  : type a. a t -> a -> int -> int -> unit
+  = function
+  | Bytes -> Bytes.set_16
+  | Bigstring -> Bigstring.set_16
 
 let set_u32
-  : type a. a t -> int -> int32 -> unit
-  = fun v idx u -> match v with
-  | Bytes v -> Bytes.set_u32 v idx u
-  | Bigstring v -> Bigstring.set_u32 v idx u
+  : type a. a t -> a -> int -> int32 -> unit
+  = function
+  | Bytes -> Bytes.set_32
+  | Bigstring -> Bigstring.set_32
 
-let set_u64
-  : type a. a t -> int -> int64 -> unit
-  = fun v idx u -> match v with
-  | Bytes v -> Bytes.set_u64 v idx u
-  | Bigstring v -> Bigstring.set_u64 v idx u
+let set_64
+  : type a. a t -> a -> int -> int64 -> unit
+  = function
+  | Bytes -> Bytes.set_64
+  | Bigstring -> Bigstring.set_64
 
 let sub
-  : type a. a t -> int -> int -> a t
-  = fun v off len -> match v with
-  | Bytes v -> Bytes.sub v off len |> from_bytes
-  | Bigstring v -> Bigstring.sub v off len |> from_bigstring
+  : type a. a t -> a -> int -> int -> a
+  = function
+  | Bytes -> Bytes.sub
+  | Bigstring -> Bigstring.sub
 
 let fill
-  : type a. a t -> int -> int -> char -> unit
-  = fun v off len chr -> match v with
-  | Bytes v -> Bytes.fill v off len chr
-  | Bigstring v -> Bigstring.fill (Bigstring.sub v off len) chr
+  : type a. a t -> a -> int -> int -> char -> unit
+  = function
+  | Bytes -> Bytes.fill
+  | Bigstring -> fun v off len chr -> Bigstring.fill (Bigstring.sub v off len) chr
 
 let blit
-  : type a. a t -> int -> a t -> int -> int -> unit
-  = fun src src_idx dst dst_idx len -> match src, dst with
-  | Bytes src, Bytes dst ->
-    Bytes.blit src src_idx dst dst_idx len
-  | Bigstring src, Bigstring dst ->
-    Bigstring.blit src src_idx dst dst_idx len
+  : type a. a t -> a -> int -> a -> int -> int -> unit
+  = function
+  | Bytes -> Bytes.blit
+  | Bigstring -> Bigstring.blit
 
 let blit2
-  : type a. a t -> int -> a t -> int -> a t -> int -> int -> unit
-  = fun src src_idx dst0 dst_idx0 dst1 dst_idx1  len -> match src, dst0, dst1 with
-  | Bytes src, Bytes dst0, Bytes dst1 ->
-    Bytes.blit2 src src_idx dst0 dst_idx0 dst1 dst_idx1 len
-  | Bigstring src, Bigstring dst0, Bigstring dst1 ->
-    Bigstring.blit2 src src_idx dst0 dst_idx0 dst1 dst_idx1 len
+  : type a. a t -> a -> int -> a -> int -> a -> int -> int -> unit
+  = function
+  | Bytes -> Bytes.blit2
+  | Bigstring -> Bigstring.blit2
 
 let pp
-  : type a. Format.formatter -> a t -> unit
-  = fun fmt -> function
-  | Bytes v -> Format.fprintf fmt "%a" Bytes.pp v
-  | Bigstring v -> Format.fprintf fmt "%a" Bigstring.pp v
+  : type a. a t -> Format.formatter -> a -> unit
+  = function
+  | Bytes -> Bytes.pp
+  | Bigstring -> Bigstring.pp
 
 let to_string
-  : type a. a t -> string
+  : type a. a t -> a -> string
   = function
-  | Bytes v -> Bytes.to_string v
-  | Bigstring v -> Bigstring.to_string v
+  | Bytes -> Bytes.to_string
+  | Bigstring -> Bigstring.to_string
 
 let empty
-  : type a. proof:a t -> a t
-  = fun ~proof -> match proof with
-  | Bytes _ -> Bytes Bytes.empty
-  | Bigstring _ -> Bigstring Bigstring.empty
-
-let proof_bytes = Bytes Bytes.empty
-let proof_bigstring = Bigstring Bigstring.empty
+  : type a. a t -> a
+  = function
+  | Bytes -> Bytes.empty
+  | Bigstring -> Bigstring.empty

--- a/lib/decompress_bigstring.ml
+++ b/lib/decompress_bigstring.ml
@@ -1,0 +1,103 @@
+let invalid_arg fmt = Format.ksprintf (fun s -> invalid_arg s) fmt
+
+open Bigarray
+
+type t = (char, int8_unsigned_elt, c_layout) Array1.t
+
+let length a = Array1.dim a
+let create l = Array1.create Char c_layout l
+let get a i = Array1.get a i
+let set a i v = Array1.set a i v
+let sub v o l = Array1.sub v o l
+let fill a v = Array1.fill a v
+
+external unsafe_get : t -> int -> char = "%caml_ba_unsafe_ref_1"
+external unsafe_set : t -> int -> char -> unit = "%caml_ba_unsafe_set_1"
+
+let copy v =
+  let v' = create (length v) in
+  Array1.blit v v'; v'
+
+external get_unsafe_16 : t -> int -> int = "%caml_bigstring_get16u"
+external get_unsafe_32 : t -> int -> int32 = "%caml_bigstring_get32u"
+external get_unsafe_64 : t -> int -> int64 = "%caml_bigstring_get64u"
+
+let get_16 t i =
+  if i < 0 || i > length t - 2
+  then invalid_arg "Bigstring.get_16"
+  else get_unsafe_16 t i
+
+let get_32 t i =
+  if i < 0 || i > length t - 4
+  then invalid_arg "Bigstring.get_32"
+  else get_unsafe_32 t i
+
+let get_64 t i =
+  if i < 0 || i > length t - 8
+  then invalid_arg "Bigstring.get_64"
+  else get_unsafe_64 t i
+
+external set_unsafe_16 : t -> int -> int -> unit = "%caml_bigstring_set16u"
+external set_unsafe_32 : t -> int -> int32 -> unit = "%caml_bigstring_set32u"
+external set_unsafe_64 : t -> int -> int64 -> unit = "%caml_bigstring_set64u"
+
+let set_16 t i =
+  if i < 0 || i > length t - 2
+  then invalid_arg "Bigstring.set_16"
+  else set_unsafe_16 t i
+
+
+let set_32 t i =
+  if i < 0 || i > length t - 4
+  then invalid_arg "Bigstring.set_32"
+  else set_unsafe_32 t i
+
+let set_64 t i =
+  if i < 0 || i > length t - 8
+  then invalid_arg "Bigstring.set_64"
+  else set_unsafe_64 t i
+
+let to_string v =
+  let buf = Bytes.create (length v) in
+  for i = 0 to length v - 1
+  do Bytes.set buf i (get v i) done;
+  Bytes.unsafe_to_string buf
+
+let unsafe_blit src src_off dst dst_off len =
+  for i = 0 to len - 1
+  do set dst (dst_off + i) (get src (src_off + i)) done
+
+let blit src src_off dst dst_off len =
+  if len < 0 || src_off < 0 || src_off > length src - len
+             || dst_off < 0 || dst_off > length dst - len
+  then invalid_arg "Bigstring.blit (src: %d:%d, \
+                                    dst: %d:%d, \
+                                    len: %d)"
+      src_off (length src)
+      dst_off (length dst)
+      len
+  else unsafe_blit src src_off dst dst_off len
+
+let blit2 src src_off dst0 dst_off0 dst1 dst_off1 len =
+  if len < 0 || src_off < 0  || src_off > length src - len
+     || dst_off0 < 0 || dst_off0 > length dst0 - len
+     || dst_off1 < 0 || dst_off1 > length dst1 - len
+  then invalid_arg "Bigstring.blit2 (src: %d:%d, \
+                                     dst0: %d:%d, \
+                                     dst1 %d:%d, \
+                                     len: %d)"
+      src_off (length src)
+      dst_off0 (length dst0)
+      dst_off1 (length dst1)
+      len
+  else
+    for i = 0 to len - 1 do
+      unsafe_set dst0 (dst_off0 + i) (unsafe_get src (src_off + i));
+      unsafe_set dst1 (dst_off1 + i) (unsafe_get src (src_off + i));
+    done
+
+let pp ppf a =
+  for i = 0 to length a - 1
+  do Format.fprintf ppf "%02X" (Char.code (unsafe_get a i)) done
+
+let empty = create 0

--- a/lib/decompress_bytes.ml
+++ b/lib/decompress_bytes.ml
@@ -1,0 +1,80 @@
+let invalid_arg fmt = Format.ksprintf (fun s -> invalid_arg s) fmt
+
+include Bytes
+
+external get_unsafe_16 : t -> int -> int = "%caml_string_get16u"
+external get_unsafe_32 : t -> int -> int32 = "%caml_string_get32u"
+external get_unsafe_64 : t -> int -> int64 = "%caml_string_get64u"
+
+let get_16 t i =
+  if i < 0 || i > length t - 2
+  then invalid_arg "Bytes.get_16"
+  else get_unsafe_16 t i
+
+let get_32 t i =
+  if i < 0 || i > length t - 4
+  then invalid_arg "Bytes.get_32"
+  else get_unsafe_32 t i
+
+let get_64 t i =
+  if i < 0 || i > length t - 8
+  then invalid_arg "Bytes.get_64"
+  else get_unsafe_64 t i
+
+external set_unsafe_16 : t -> int -> int -> unit = "%caml_string_set16u"
+external set_unsafe_32 : t -> int -> int32 -> unit = "%caml_string_set32u"
+external set_unsafe_64 : t -> int -> int64 -> unit = "%caml_string_set64u"
+
+let set_16 t i =
+  if i < 0 || i > length t - 2
+  then invalid_arg "Bytes.set_16"
+  else set_unsafe_16 t i
+
+
+let set_32 t i =
+  if i < 0 || i > length t - 4
+  then invalid_arg "Bytes.set_32"
+  else set_unsafe_32 t i
+
+
+let set_64 t i =
+  if i < 0 || i > length t - 8
+  then invalid_arg "Bytes.set_64"
+  else set_unsafe_64 t i
+
+let unsafe_blit src src_off dst dst_off len =
+  for i = 0 to len - 1
+  do unsafe_set dst (dst_off + i) (unsafe_get src (src_off + i)) done
+
+let blit src src_off dst dst_off len =
+  if len < 0 || src_off < 0 || src_off > length src - len
+              || dst_off < 0 || dst_off > length dst - len
+  then invalid_arg "Bytes.blit (src: %d:%d, \
+                                dst: %d:%d, \
+                                len: %d)"
+      src_off (length src)
+      dst_off (length dst)
+      len
+  else unsafe_blit src src_off dst dst_off len
+
+let blit2 src src_off dst0 dst_off0 dst1 dst_off1 len =
+  if len < 0 || src_off < 0  || src_off > length src - len
+     || dst_off0 < 0 || dst_off0 > length dst0 - len
+     || dst_off1 < 0 || dst_off1 > length dst1 - len
+  then invalid_arg "Bytes.blit2 (src: %d:%d, \
+                                 dst0: %d:%d, \
+                                 dst1: %d:%d, \
+                                 len: %d)"
+      src_off (length src)
+      dst_off0 (length dst0)
+      dst_off1 (length dst1)
+      len
+  else
+    for i = 0 to len - 1 do
+      unsafe_set dst0 (dst_off0 + i) (unsafe_get src (src_off + i));
+      unsafe_set dst1 (dst_off1 + i) (unsafe_get src (src_off + i));
+    done
+
+let pp ppf a =
+  for i = 0 to length a - 1
+  do Format.fprintf ppf "%02X" (Char.code (unsafe_get a i)) done

--- a/lib/decompress_lz77.ml
+++ b/lib/decompress_lz77.ml
@@ -1,6 +1,9 @@
-module Safe    = Decompress_safe
-module Seq     = Decompress_seq
-module Hunk    = Decompress_hunk
+module Safe = Decompress_safe
+module Seq = Decompress_seq
+module Hunk = Decompress_hunk
+module B = Decompress_b
+
+let pf = Format.fprintf
 
 let repeat atm =
   let atm = Char.code atm |> Int64.of_int in
@@ -33,7 +36,8 @@ type 'i t =
   ; i_len      : int
   ; level      : int
   ; on         : Hunk.t -> unit
-  ; state      : 'i state }
+  ; state      : 'i state
+  ; witness    : 'i B.t }
 and 'i state =
   | Deflate   of int
   | Deffast   of int
@@ -43,29 +47,25 @@ and 'i res =
   | Cont  of 'i t
   | Wait  of 'i t * Hunk.t Seq.t
   | Error of 'i t * error
-(** XXX: we don't have an [Ok] result because this algorithm does not decide
-          if you need to stop the compression or not - this is decided by the
-          user. It's illogic to force a [`End] state with this algorithm. *)
 
-let pp_state fmt = function
-  | Deflate wbits -> Format.fprintf fmt "(Deflate wbits:%d)" wbits
-  | Deffast wbits -> Format.fprintf fmt "(Deffast wbits:%d)" wbits
-  | Choose wbits -> Format.fprintf fmt "(Choose wbits:%d)" wbits
-  | Exception exn -> Format.fprintf fmt "(Exception %a)" pp_error exn
+(* XXX: we don't have an [Ok] result because this algorithm does not decide if
+   you need to stop the compression or not - this is decided by the user. It's
+   illogic to force a [`End] state with this algorithm. *)
 
-let pp fmt { i_off; i_pos; i_len
-            ; level
-            ; state
-            ; _ } =
-  Format.fprintf fmt "{@[<hov>i_off = %d;@ \
-                              i_pos = %d;@ \
-                              i_len = %d;@ \
-                              level = %d;@ \
-                              on = #fun;@ \
-                              state = %a@]}"
-    i_off i_pos i_len
-    level
-    pp_state state
+let pp_state ppf = function
+  | Deflate wbits -> pf ppf "(Deflate wbits:%d)" wbits
+  | Deffast wbits -> pf ppf "(Deffast wbits:%d)" wbits
+  | Choose wbits -> pf ppf "(Choose wbits:%d)" wbits
+  | Exception exn -> pf ppf "(Exception @[%a@])" pp_error exn
+
+let pp ppf { i_off; i_pos; i_len; level; state; _ } =
+  pf ppf "{@[<hov>i_off = %d;@ \
+                  i_pos = %d;@ \
+                  i_len = %d;@ \
+                  level = %d;@ \
+                  on = #fun;@ \
+                  state = @[%a@]@]}"
+    i_off i_pos i_len level pp_state state
 
 let await t lst = Wait (t, lst)
 let error t exn = Error ({ t with state = Exception exn }, exn)
@@ -75,11 +75,11 @@ let _max_length      = 256
 let _size_of_int64   = 8
 let _idx_boundary    = 2
 
-type key = Int32.t option
+type key = int32 option
 
-let key src idx len : key =
+let key witness src idx len : key =
   if idx < len - 3
-  then Some (Safe.get_u32 src idx)
+  then Some (Safe.get_32 witness src idx)
   else None
 
 module T =
@@ -93,19 +93,18 @@ struct
     Hashtbl.replace table key (value :: rest)
 end
 
-let longuest_substring src x y len =
+let longuest_substring witness src x y len =
   let rec aux acc l =
     if l < _max_length
     && x + l < y
     && y + l < len
-    && Safe.get src (x + l) = Safe.get src (y + l)
+    && Safe.get witness src (x + l) = Safe.get witness src (y + l)
     then aux (Some (l + 1)) (l + 1)
-    else acc
-  in
+    else acc in
   aux None 0
 
 (* XXX: from ocaml-lz77, no optimized but this algorithm has no constraint.
-    bisoux @samoht. *)
+   bisoux @samoht. *)
 let deflate ?(max_fardistance = (1 lsl 15) - 1) src t =
   let results = Queue.create () in
   let src_idx = ref (t.i_off + t.i_pos) in
@@ -113,17 +112,15 @@ let deflate ?(max_fardistance = (1 lsl 15) - 1) src t =
   let last    = ref 0 in
 
   let flush_last () =
-    if !last <> 0 then begin
+    if !last <> 0
+    then begin
       for i = 0 to !last - 1
-      do t.on (Hunk.Literal (Safe.get src (!src_idx - !last + i)));
-          Queue.push
-            (Hunk.Literal (Safe.get src (!src_idx - !last + i)))
-            results;
-      done;
-
-      last := 0
-    end
-  in
+      do let hunk = Hunk.Literal (Safe.get t.witness src (!src_idx - !last + i)) in
+         t.on hunk
+       ; Queue.push hunk results
+      done
+    ; last := 0
+    end in
 
   let find_match idx =
 
@@ -132,10 +129,9 @@ let deflate ?(max_fardistance = (1 lsl 15) - 1) src t =
       | Some (_, x), Some (_, y) -> if x >= y then a else b
       | Some _, None -> a
       | None, Some _ -> b
-      | None, None -> None
-    in
+      | None, None -> None in
 
-    let key = key src idx (t.i_off + t.i_len) in
+    let key = key t.witness src idx (t.i_off + t.i_len) in
     let candidates = T.find table key in
     let rec aux acc = function
       | [] -> acc
@@ -143,35 +139,33 @@ let deflate ?(max_fardistance = (1 lsl 15) - 1) src t =
         if x >= idx
         || idx - x >= max_fardistance
         then acc
-        else match longuest_substring src x idx (t.i_off + t.i_len) with
+        else match longuest_substring t.witness src x idx (t.i_off + t.i_len) with
           | Some len when len >= 3 -> aux (max acc (Some (x, len))) r
           | _ -> aux acc r
     in
 
     match aux None candidates with
     | None -> None
-    | Some (i, len) -> Some (idx - i, len)
-  in
+    | Some (i, len) -> Some (idx - i, len) in
 
   while !src_idx < t.i_off + t.i_len
   do match find_match !src_idx with
       | None ->
-        T.add (key src !src_idx (t.i_off + t.i_len)) !src_idx table;
-        incr last;
-        incr src_idx;
+        T.add (key t.witness src !src_idx (t.i_off + t.i_len)) !src_idx table
+      ; incr last
+      ; incr src_idx
       | Some (start, len) ->
         for i = !src_idx to !src_idx + len - 1
-        do T.add (key src i (t.i_off + t.i_len)) i table done;
+        do T.add (key t.witness src i (t.i_off + t.i_len)) i table done
 
-        flush_last ();
-        t.on (Hunk.Match (len - 3, start - 1));
-        Queue.push (Hunk.Match (len - 3, start - 1)) results;
-        src_idx := !src_idx + len
-  done;
+      ; flush_last ()
+      ; t.on (Hunk.Match (len - 3, start - 1))
+      ; Queue.push (Hunk.Match (len - 3, start - 1)) results
+      ; src_idx := !src_idx + len
+  done
 
-  flush_last ();
-
-  Seq.of_queue results
+  ; flush_last ()
+  ; Seq.of_queue results
 
 let _hlog = [| 0; 11; 11; 11; 12; 13; 13; 13; 13; 13 |]
 
@@ -180,7 +174,7 @@ let deffast
   : type a.
     ?accel:int ->
     ?max_fardistance:int ->
-    (Safe.read, a) Safe.t -> a t -> Hunk.t Seq.t
+    (Safe.ro, a) Safe.t -> a t -> Hunk.t Seq.t
   = fun ?(accel = 1) ?(max_fardistance = (1 lsl 15) - 1) src t ->
   let src_idx    = ref (t.i_off + t.i_pos) in
   let hash_log   = Array.get _hlog t.level in
@@ -190,23 +184,22 @@ let deffast
   let results    = Queue.create () in
   let accel      = if accel < 1 then 0 else accel - 1 in
 
-  t.on (Hunk.Literal (Safe.get src !src_idx));
-  Queue.push (Hunk.Literal (Safe.get src !src_idx)) results;
+  t.on (Hunk.Literal (Safe.get t.witness src !src_idx));
+  Queue.push (Hunk.Literal (Safe.get t.witness src !src_idx)) results;
   incr src_idx;
 
-  t.on (Hunk.Literal (Safe.get src !src_idx));
-  Queue.push (Hunk.Literal (Safe.get src !src_idx)) results;
+  t.on (Hunk.Literal (Safe.get t.witness src !src_idx));
+  Queue.push (Hunk.Literal (Safe.get t.witness src !src_idx)) results;
   incr src_idx;
 
   let c ref idx =
     try
-      if Safe.get src !ref = Safe.get src !idx
+      if Safe.get t.witness src !ref = Safe.get t.witness src !idx
       then begin incr ref;
                   incr idx;
                   true
       end else false
-    with _ -> false
-  in
+    with _ -> false in
 
   while !src_idx < t.i_off + t.i_len - 12
   do
@@ -214,13 +207,13 @@ let deffast
     let src_ref = ref !src_idx in
 
     try
-      if Safe.get src !src_idx = Safe.get src (!src_idx - 1)
-          && Safe.get_u16 src (!src_idx - 1) = Safe.get_u16 src (!src_idx + 1)
+      if Safe.get t.witness src !src_idx = Safe.get t.witness src (!src_idx - 1)
+      && Safe.get_16 t.witness src (!src_idx - 1) = Safe.get_16 t.witness src (!src_idx + 1)
       then raise (Match (0, 0)) (* (+3, +1) *);
 
       let hval =
-        let v = Safe.get_u16 src !src_idx in
-        let v = (Safe.get_u16 src (!src_idx + 1)
+        let v = Safe.get_16 t.witness src !src_idx in
+        let v = (Safe.get_16 t.witness src (!src_idx + 1)
                   lxor (v lsr (16 - hash_log))) lxor v in
         v land ((1 lsl hash_log) - 1)
       in
@@ -235,27 +228,27 @@ let deffast
           || c src_ref src_idx = false
           || c src_ref src_idx = false
           || c src_ref src_idx = false
-      then raise (Literal (Safe.get src anchor));
+      then raise (Literal (Safe.get t.witness src anchor));
 
       if t.level >= 5 && distance >= _max_distance
       then if c src_ref src_idx = false
             || c src_ref src_idx = false
-            then raise (Literal (Safe.get src anchor))
+            then raise (Literal (Safe.get t.witness src anchor))
             else raise (Match (2, distance - 1)) (* (+3, +1) *);
 
       raise (Match (!src_idx - anchor - 3, distance - 1))
     with Match (len, 0) ->
           begin
-            let pattern = Safe.get src (anchor + len - 1) in
+            let pattern = Safe.get t.witness src (anchor + len - 1) in
             let v1 = repeat pattern in
 
             (*  _ _ _ _
-            * |_|_|_|_|
-            * | | | | src_idx
-            * | | | src_ref
-            * | | anchor
-            * | -1
-            *)
+             * |_|_|_|_|
+             * | | | | src_idx
+             * | | | src_ref
+             * | | anchor
+             * | -1
+             *)
 
             src_idx := anchor + (len + 3);
             (* XXX: in blosclz, [src_ref = anchor - 1 + 3], but in this case,
@@ -269,14 +262,14 @@ let deffast
                               - (2 * _idx_boundary)
                     && !src_idx - 3 - anchor < _max_length - _size_of_int64
               do
-                let v2 = Safe.get_u64 src !src_ref in
+                let v2 = Safe.get_64 t.witness src !src_ref in
 
                 if v1 <> v2
                 then begin
                   while !src_idx < (t.i_off + t.i_len) - _idx_boundary
                         && !src_idx - 3 - anchor < _max_length
                   do
-                    if Safe.get src !src_ref <> pattern
+                    if Safe.get t.witness src !src_ref <> pattern
                     then raise Break
                     else begin incr src_ref; incr src_idx; end
                   done;
@@ -312,7 +305,7 @@ let deffast
                               - _size_of_int64
                               - (2 * _idx_boundary)
                     && !src_idx - 3 - anchor < _max_length - _size_of_int64
-              do if Safe.get_u64 src !src_idx <> Safe.get_u64 src !src_ref
+              do if Safe.get_64 t.witness src !src_idx <> Safe.get_64 t.witness src !src_ref
                 then begin
                   while !src_idx < (t.i_off + t.i_len) - _idx_boundary
                         && !src_idx - 3 - anchor < _max_length
@@ -350,9 +343,10 @@ let deffast
   done;
 
   while !src_idx < t.i_off + t.i_len
-  do t.on (Hunk.Literal (Safe.get src !src_idx));
-      Queue.push (Hunk.Literal (Safe.get src !src_idx)) results;
-      incr src_idx
+  do let hunk = (Hunk.Literal (Safe.get t.witness src !src_idx)) in
+       t.on hunk
+     ; Queue.push hunk results;
+     ; incr src_idx
   done;
 
   Seq.of_queue results
@@ -406,26 +400,30 @@ let refill off len t =
 let used_in t = t.i_pos
 
 let default
+  ~witness
   ?(level = 0)
   ?(on = fun _ -> ())
   wbits =
   if level >= 0 && level <= 9 && wbits >= 8 && wbits <= 15
   then { i_off = 0
-        ; i_pos = 0
-        ; i_len = 0
-        ; level
-        ; on
-        ; state = Deflate wbits }
+       ; i_pos = 0
+       ; i_len = 0
+       ; level
+       ; on
+       ; state = Deflate wbits
+       ; witness }
   else if wbits >= 8 && wbits <= 15
   then { i_off = 0
-        ; i_pos = 0
-        ; i_len = 0
-        ; level = 0
-        ; on
-        ; state = Exception (Invalid_level level) }
+       ; i_pos = 0
+       ; i_len = 0
+       ; level = 0
+       ; on
+       ; state = Exception (Invalid_level level)
+       ; witness }
   else { i_off = 0
-        ; i_pos = 0
-        ; i_len = 0
-        ; level = 0
-        ; on
-        ; state = Exception (Invalid_wbits wbits) }
+       ; i_pos = 0
+       ; i_len = 0
+       ; level = 0
+       ; on
+       ; state = Exception (Invalid_wbits wbits)
+       ; witness }

--- a/lib/decompress_safe.ml
+++ b/lib/decompress_safe.ml
@@ -1,31 +1,32 @@
 module B = Decompress_b
 
-type read  = [ `Read ]
-type write = [ `Write ]
+type ro = [ `Rd ]
+type wo = [ `Wr ]
 
-type ('a, 'i) t = 'i B.t constraint 'a = [< `Read | `Write ]
+type ('a, 'i) t = 'i constraint 'a = [< `Rd | `Wr ]
 
-external read_and_write : 'i B.t -> ([ read | write ], 'i) t = "%identity"
-external read_only      : 'i B.t -> (read, 'i) t             = "%identity"
-external write_only     : 'i B.t -> (write, 'i) t            = "%identity"
+let rw : 'i B.t -> 'i -> ([ ro | wo ], 'i) t = fun _p v -> v
+let ro : 'i B.t -> 'i -> (ro, 'i) t = fun _p v -> v
+let wo : 'i B.t -> 'i -> (wo, 'i) t = fun _p v -> v
 
-let length    = B.length
-let get       = B.get
-let set       = B.set
-let get_u16   = B.get_u16
-let get_u32   = B.get_u32
-let get_u64   = B.get_u64
-let sub_ro    = B.sub
-let sub_rw    = B.sub
-let fill      = B.fill
-let blit      = B.blit
-let blit2     = B.blit2
-let pp        = B.pp
+let length = B.length
+let get = B.get
+let set = B.set
+let get_16 = B.get_16
+let get_32 = B.get_32
+let get_64 = B.get_64
+let sub_ro = B.sub
+let sub_rw = B.sub
+let fill = B.fill
+let blit = B.blit
+let blit2 = B.blit2
+let pp = B.pp
 let to_string = B.to_string
-let adler32
-    : type a. a B.t -> Checkseum.Adler32.t -> int -> int -> Checkseum.Adler32.t
-  = fun v t off len -> match v with
-  | B.Bytes v -> Checkseum.Adler32.digest_bytes v off len t
-  | B.Bigstring v -> Checkseum.Adler32.digest_bigstring v off len t
 
-external from : ('a, 'i) t -> 'i B.t = "%identity"
+let adler32
+  : type a. a B.t -> a -> int -> int -> Checkseum.Adler32.t -> Checkseum.Adler32.t
+  = function
+  | B.Bytes -> Checkseum.Adler32.digest_bytes
+  | B.Bigstring -> Checkseum.Adler32.digest_bigstring
+
+external unsafe : ('a, 'i) t -> 'i = "%identity"

--- a/lib/decompress_safe.mli
+++ b/lib/decompress_safe.mli
@@ -1,24 +1,26 @@
-type read  = [ `Read ]
-type write = [ `Write ]
+module B = Decompress_b
 
-type ('a, 'i) t constraint 'a = [< read | write ]
+type ro = [ `Rd ]
+type wo = [ `Wr ]
 
-val read_and_write : 'i Decompress_b.t -> ([ read | write ], 'i) t
-val read_only      : 'i Decompress_b.t -> (read, 'i) t
-val write_only     : 'i Decompress_b.t -> (write, 'i) t
+type ('a, 'i) t = private 'i constraint 'a = [< `Rd | `Wr ]
 
-val length    : ('a, 'i) t -> int
-val get       : ([> read ], 'i) t -> int -> char
-val set       : ([> write ], 'i) t -> int -> char -> unit
-val get_u16   : ([> read ], 'i) t -> int -> int
-val get_u32   : ([> read ], 'i) t -> int -> int32
-val get_u64   : ([> read ], 'i) t -> int -> int64
-val sub_ro    : ([> read ], 'i) t -> int -> int -> (read, 'i) t
-val sub_rw    : ([> read ], 'i) t -> int -> int -> ([ read | write ], 'i) t
-val fill      : ([> write ], 'i) t -> int -> int -> char -> unit
-val blit      : ([> read ], 'i) t -> int -> ([> write ], 'i) t -> int -> int -> unit
-val blit2     : ([> read ], 'i) t -> int -> ([> write ], 'i) t -> int -> ([> write ], 'i) t -> int -> int -> unit
-val pp        : Format.formatter -> ([> read ], 'i) t -> unit
-val to_string : ([> read ], 'i) t -> string
-val adler32   : ([> read ], 'i) t -> Checkseum.Adler32.t -> int -> int -> Checkseum.Adler32.t
-val from      : ('a, 'i) t -> 'i Decompress_b.t
+val rw : 'i B.t -> 'i -> ([ ro | wo ], 'i) t
+val ro : 'i B.t -> 'i -> (ro, 'i) t
+val wo : 'i B.t -> 'i -> (wo, 'i) t
+
+val length : 'i B.t -> ('a, 'i) t -> int
+val get : 'i B.t -> ([> ro ], 'i) t -> int -> char
+val set : 'i B.t -> ([> wo ], 'i) t -> int -> char -> unit
+val get_16 : 'i B.t -> ([> ro ], 'i) t -> int -> int
+val get_32 : 'i B.t -> ([> ro ], 'i) t -> int -> int32
+val get_64 : 'i B.t -> ([> ro ], 'i) t -> int -> int64
+val sub_ro : 'i B.t -> ([> ro ], 'i) t -> int -> int -> (ro, 'i) t
+val sub_rw : 'i B.t -> ([> ro ], 'i) t -> int -> int -> ([ ro | wo ], 'i) t
+val fill : 'i B.t -> ([> wo ], 'i) t -> int -> int -> char -> unit
+val blit : 'i B.t -> ([> ro ], 'i) t -> int -> ([> wo ], 'i) t -> int -> int -> unit
+val blit2 : 'i B.t -> ([> ro ], 'i) t -> int -> ([> wo ], 'i) t -> int -> ([> wo ], 'i) t -> int -> int -> unit
+val pp : 'i B.t -> Format.formatter -> ([> ro ], 'i) t -> unit
+val to_string : 'i B.t -> ([> ro ], 'i) t -> string
+val adler32 : 'i B.t -> ([> ro ], 'i) t -> int -> int -> Checkseum.Adler32.t -> Checkseum.Adler32.t
+val unsafe : ('a, 'i) t -> 'i

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,6 +1,8 @@
 (library
  ((name decompress_impl)
   (modules (decompress_b
+            decompress_bigstring
+            decompress_bytes
             decompress_hunk
             decompress_impl
             decompress_lz77

--- a/lib/rfc1951.ml
+++ b/lib/rfc1951.ml
@@ -27,7 +27,7 @@ sig
   val flush_of_meth: meth -> (int -> int -> ('x, 'x) t -> ('x, 'x) t)
   val flush: int -> int -> ('i, 'o) t -> ('i, 'o) t
 
-  val eval            : 'a B.t -> 'a B.t -> ('a, 'a) t ->
+  val eval            : 'a -> 'a -> ('a, 'a) t ->
     [ `Await of ('a, 'a) t
     | `Flush of ('a, 'a) t
     | `End   of ('a, 'a) t
@@ -37,20 +37,20 @@ sig
   val used_out: ('i, 'o) t -> int
   val bits_remaining: ('x, 'x) t -> int
 
-  val default: proof:'o B.t -> ?wbits:int -> int -> ('i, 'o) t
+  val default: witness:'a B.t -> ?wbits:int -> int -> ('a, 'a) t
 
-  val to_result: 'a B.t -> 'a B.t -> ?meth:(meth * int) ->
-                 ('a B.t -> int option -> int) ->
-                 ('a B.t -> int -> int) ->
+  val to_result: 'a -> 'a -> ?meth:(meth * int) ->
+                 ('a -> int option -> int) ->
+                 ('a -> int -> int) ->
                  ('a, 'a) t -> (('a, 'a) t, error) result
   val bytes: Bytes.t -> Bytes.t -> ?meth:(meth * int) ->
              (Bytes.t -> int option -> int) ->
              (Bytes.t -> int -> int) ->
-             (B.st, B.st) t -> ((B.st, B.st) t, error) result
+             (Bytes.t, Bytes.t) t -> ((Bytes.t, Bytes.t) t, error) result
   val bigstring: B.Bigstring.t -> B.Bigstring.t -> ?meth:(meth * int) ->
                  (B.Bigstring.t -> int option -> int) ->
                  (B.Bigstring.t -> int -> int) ->
-                 (B.bs, B.bs) t -> ((B.bs, B.bs) t, error) result
+                 (B.Bigstring.t, B.Bigstring.t) t -> ((B.Bigstring.t, B.Bigstring.t) t, error) result
 end
 
 type error_deflate = Decompress_impl.error_rfc1951_deflate = Lz77 of L.error
@@ -67,7 +67,7 @@ sig
   val pp_error: Format.formatter -> error -> unit
   val pp: Format.formatter -> ('i, 'o) t -> unit
 
-  val eval: 'a B.t -> 'a B.t -> ('a, 'a) t ->
+  val eval: 'a -> 'a -> ('a, 'a) t ->
     [ `Await of ('a, 'a) t
     | `Flush of ('a, 'a) t
     | `End   of ('a, 'a) t
@@ -81,20 +81,20 @@ sig
   val write: ('i, 'o) t -> int
   val bits_remaining: ('x, 'x) t -> int
 
-  val default: 'o Window.t -> ('i, 'o) t
+  val default: witness:'a B.t -> 'a Window.t -> ('a, 'a) t
 
-  val to_result: 'a B.t -> 'a B.t ->
-                 ('a B.t -> int) ->
-                 ('a B.t -> int -> int) ->
+  val to_result: 'a -> 'a ->
+                 ('a -> int) ->
+                 ('a -> int -> int) ->
                  ('a, 'a) t -> (('a, 'a) t, error) result
   val bytes: Bytes.t -> Bytes.t ->
              (Bytes.t -> int) ->
              (Bytes.t -> int -> int) ->
-             (B.st, B.st) t -> ((B.st, B.st) t, error) result
+             (Bytes.t, Bytes.t) t -> ((Bytes.t, Bytes.t) t, error) result
   val bigstring: B.Bigstring.t -> B.Bigstring.t ->
                  (B.Bigstring.t -> int) ->
                  (B.Bigstring.t -> int -> int) ->
-                 (B.bs, B.bs) t -> ((B.bs, B.bs) t, error) result
+                 (B.Bigstring.t, B.Bigstring.t) t -> ((B.Bigstring.t, B.Bigstring.t) t, error) result
 end
 
 type error_inflate = Decompress_impl.error_rfc1951_inflate =

--- a/test/test.ml
+++ b/test/test.ml
@@ -10,7 +10,8 @@ let walk directory pattern =
           match (Unix.stat kind).Unix.st_kind with
           | Unix.S_REG -> (dirs, kind :: files)
           | Unix.S_DIR -> (kind :: dirs, files)
-          | _ -> (dirs, files))
+          | (Unix.S_BLK | Unix.S_CHR | Unix.S_FIFO | Unix.S_LNK | Unix.S_SOCK) -> (dirs, files)
+          | exception (Unix.Unix_error _) -> (dirs, files))
           ([], []) contents
       in
       let matched = List.filter select files in

--- a/test/test.ml
+++ b/test/test.ml
@@ -58,13 +58,13 @@ struct
 
   let input  = Bytes.create 0xFFFF
   let output = Bytes.create 0xFFFF
-  let window = Decompress.Window.create ~proof:Decompress.B.proof_bytes
+  let window = Decompress.Window.create ~witness:Decompress.B.bytes
 
   let compress ?(level = 4) ?(wbits = 15) ?meth refill flush =
     Decompress.Zlib_deflate.bytes input output ?meth
       refill
       (fun buf len -> flush buf len; 0xFFFF)
-      (Decompress.Zlib_deflate.default ~proof:(Decompress.B.from_bytes Bytes.empty) level ~wbits)
+      (Decompress.Zlib_deflate.default ~witness:Decompress.B.bytes level ~wbits)
     |> function
        | Ok _ -> ()
        | Error exn -> raise (Decompress_deflate exn)
@@ -73,7 +73,7 @@ struct
     Decompress.Zlib_inflate.bytes input output
       refill
       (fun buf len -> flush buf len; 0xFFFF)
-      (Decompress.Zlib_inflate.default (Decompress.Window.reset window))
+      (Decompress.Zlib_inflate.default ~witness:Decompress.B.bytes (Decompress.Window.reset window))
     |> function
        | Ok _ -> ()
        | Error exn -> raise (Decompress_inflate exn)


### PR DESCRIPTION
This PR _unbox_ buffers but keep constraints with GADT. User can directly use a `Bytes.t` or a `Bigstring.t` and it's not needed to wrap it on `Decompress.B.t` value.