### PR TITLE
Fix #68 - switch to Unix.map_file

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -2,7 +2,7 @@
  (name test_on_files)
  (package decompress)
  (modules test_on_files)
- (libraries checkseum.c decompress re.str camlzip alcotest bos))
+ (libraries checkseum.c decompress re.str camlzip alcotest bos unix))
 
 (test
  (name test_rfc1951)

--- a/test/test_on_files.ml
+++ b/test/test_on_files.ml
@@ -31,8 +31,8 @@ let string_of_file filename =
 let bigstring_of_file filename =
   let i = Unix.openfile filename [Unix.O_RDONLY] 0o644 in
   let m =
-    (Bigarray.Array1.map_file [@warning "-3"]) i Bigarray.Char
-      Bigarray.c_layout false (-1)
+    Bigarray.array1_of_genarray (Unix.map_file i ~pos:0L
+      Bigarray.Char Bigarray.c_layout false [|(-1)|])
   in
   at_exit (fun () -> Unix.close i) ;
   m


### PR DESCRIPTION
Bigarray.Array1.map_file is deprecated, and recommended
way is to use Bigarray.array1_of_genarray and Unix.map_file.