### PR TITLE
V0.9.0+bigarray compat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### v0.9.1 2019-10-08 Palmarin (Sénégal)
+
+* Compatibility layer with `bigarray-compat`
+
 ### v0.9.0 2019-07-10 Paris (France)
 
 * Add support of 4.07 and 4.08 in Travis (@XVilka, @dinosaure, #70, #71)

--- a/bin/dpipe.ml
+++ b/bin/dpipe.ml
@@ -1,6 +1,7 @@
 let () = Printexc.record_backtrace true
 
 module Buffer = Decompress.Buffer
+module Bigarray = Bigarray_compat
 
 external bs_read :
   Unix.file_descr -> Buffer.Bigstring.t -> int -> int -> int

--- a/decompress.opam
+++ b/decompress.opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {build}
   "base-bytes"
-  "base-bigarray"
+  "bigarray-compat"
   "mmap"
   "optint"
   "checkseum"

--- a/lib/decompress.mli
+++ b/lib/decompress.mli
@@ -1,7 +1,7 @@
 module Buffer : sig
   module Bigstring : sig
     type t =
-      (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+      (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
   end
 
   type 'a t = Bytes : Bytes.t t | Bigstring : Bigstring.t t

--- a/lib/decompress_bigstring.ml
+++ b/lib/decompress_bigstring.ml
@@ -1,6 +1,6 @@
 let invalid_arg fmt = Format.ksprintf (fun s -> invalid_arg s) fmt
 
-open Bigarray
+open Bigarray_compat
 
 type t = (char, int8_unsigned_elt, c_layout) Array1.t
 

--- a/lib/dune
+++ b/lib/dune
@@ -19,7 +19,7 @@
  (flags (:standard -w +1..49 -w -4-41-44))
  (ocamlopt_flags (:standard -unbox-closures -unbox-closures-factor 20))
  (public_name decompress.impl)
- (libraries bigarray checkseum))
+ (libraries bigarray-compat checkseum))
 
 (library
  (name decompress)

--- a/lib/rfc1951.mli
+++ b/lib/rfc1951.mli
@@ -1,7 +1,7 @@
 module Buffer : sig
   module Bigstring : sig
     type t =
-      (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+      (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
   end
 
   type 'a t = Bytes : Bytes.t t | Bigstring : Bigstring.t t

--- a/rfc1951.opam
+++ b/rfc1951.opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {build}
   "base-bytes"
-  "base-bigarray"
+  "bigarray-compat"
   "optint"
   "checkseum"
   "decompress"


### PR DESCRIPTION
Fake release to be able to use `decompress` with MirageOS + dune. `bigarray-compat` package added. This PR will not be merged.