### PR TITLE
Zlib header really does not block

### DIFF
--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -248,8 +248,8 @@ module Inf = struct
       || cm != _deflated
       then err_invalid_header d
       else
-        ( De.Inf.src state d.i d.i_pos (i_rem d)
-        ; decode { d with hd= unsafe_get_uint16 d.i d.i_pos
+        ( if i_rem d > 0 then De.Inf.src state d.i d.i_pos (i_rem d)
+        ; decode { d with hd= unsafe_get_uint16 d.t 0
                         ; k= decode
                         ; dd
                         ; t_need= 0; t_len= 0

--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -252,6 +252,7 @@ module Inf = struct
         ; decode { d with hd= unsafe_get_uint16 d.i d.i_pos
                         ; k= decode
                         ; dd
+                        ; t_need= 0; t_len= 0
                         ; fdict= fdict == 1; flevel; cinfo } ) in
     if i_rem d >= 2
     then ( unsafe_set_uint16 d.t 0 (unsafe_get_uint16 d.i d.i_pos)

--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -235,7 +235,7 @@ module Inf = struct
   let rec header d =
     let k d =
       let[@warning "-8"] Hd { o; } = d.dd in
-      let cmf = unsafe_get_uint16 d.i d.i_pos in
+      let cmf = unsafe_get_uint16 d.t 0 in
       let cm = cmf land 0b1111 in
       let cinfo = (cmf lsr 4) land 0b1111 in
       let flg = cmf lsr 8 in
@@ -248,17 +248,18 @@ module Inf = struct
       || cm != _deflated
       then err_invalid_header d
       else
-        ( De.Inf.src state d.i (d.i_pos + 2) (i_rem { d with i_pos= d.i_pos + 2 })
+        ( De.Inf.src state d.i d.i_pos (i_rem d)
         ; decode { d with hd= unsafe_get_uint16 d.i d.i_pos
                         ; k= decode
                         ; dd
-                        ; fdict= fdict == 1; flevel; cinfo
-                        ; i_pos= d.i_pos + 2 } ) in
+                        ; fdict= fdict == 1; flevel; cinfo } ) in
     if i_rem d >= 2
-    then k d
+    then ( unsafe_set_uint16 d.t 0 (unsafe_get_uint16 d.i d.i_pos)
+         ; k { d with i_pos= d.i_pos + 2 } )
     else ( if i_rem d < 0
            then err_unexpected_end_of_input d
-           else refill decode (* XXX(dinosaure): it should be safe to replace it by [header] *) d )
+           else if i_rem d == 0 then refill header d
+           else t_fill k (t_need 2 d) )
 
   and decode d = match d.dd with
     | Hd _ -> header d


### PR DESCRIPTION
A well-know bug about the header of `zlib` but it should never happened in a usual context. However, for such libraries like `carton`, the length of inputs can be less than 2 bytes.

This patch asks 2 bytes at the beginning and if they are not available, we use a internal mechanism to start a continuation until we don't have these 2 bytes.

 A test can be done for this case, may be I will do that this week or next week.