### PR TITLE
Fix misuse of Zl API

### DIFF
--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -311,7 +311,7 @@ module Inf = struct
       De.Inf.flush state ; { d with f= false }
 
   let dst_rem d = match d.dd with
-    | Hd _ -> invalid_arg "Invalid state to know bytes remaining"
+    | Hd _ -> 0
     | Dd { state; _ } -> De.Inf.dst_rem state
 
   let src_rem d = i_rem d


### PR DESCRIPTION
This PR wants to fix an non essential error on the `zl` layer. In fact, it can appear that the user fill 1 byte at the beginning (eg. #84) and then call `dst_rem` in `Await` branch (as `carton` does). It's not a true error, I mean, we should not fail on this context.