### PR TITLE
Protect some array accesses with masks

### DIFF
--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1384,6 +1384,8 @@ module Inf = struct
     WInf.reset d.w
 end
 
+let unsafe_set_cursor d c = d.Inf.w.WInf.w <- c
+
 module T = struct
   module Heap = struct
     type t = { heap : int array

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -454,6 +454,8 @@ end
 
 (** / **)
 
+val unsafe_set_cursor : Inf.decoder -> int -> unit
+
 module Lookup : sig
   type t = { t : int array; m : int; l : int; }
   val get : t -> int -> int * int


### PR DESCRIPTION
It's a fix of #83. Even if it fixes the bug and return a proper error, you should add a test about that. I will try to figure out a small `gzip` data of the given example.