### PR TITLE
Swapping from arithmetic to logical bitshifts on d.hold

### DIFF
--- a/lib/de.ml
+++ b/lib/de.ml
@@ -808,28 +808,28 @@ module Inf = struct
 
       consume () ;
       len := !hold land 0xff ;
-      hold := !hold asr 8 ;
+      hold := !hold lsr 8 ;
       bits := !bits - 8 ;
 
       consume () ;
       len := ((!hold land 0xff) lsl 8) lor !len ;
-      hold := !hold asr 8 ;
+      hold := !hold lsr 8 ;
       bits := !bits - 8 ;
 
       consume () ;
       nlen := !hold land 0xff ;
-      hold := !hold asr 8 ;
+      hold := !hold lsr 8 ;
       bits := !bits - 8;
 
       consume () ;
       nlen := ((!hold land 0xff) lsl 8) lor !nlen ;
-      hold := !hold asr 8 ;
+      hold := !hold lsr 8 ;
       bits := !bits - 8 ;
 
       if !nlen != 0xffff - !len
       then err_invalid_complement_of_length d
       else ( d.hold <- 0 ; d.bits <- 0 ; d.l <- !len ; d.s <- Flat ; flat d ) in
-    d.hold <- d.hold asr (d.bits land 7) ;
+    d.hold <- d.hold lsr (d.bits land 7) ;
     (* XXX(cfcs): diff between [d.bits] and [d.bits round down to nearest multiple of 8]. *)
     let truncated_bits = d.bits land (lnot 7) in
     (* XXX(cfcs): round down to nearest multiple of 8, logical equivalents:


### PR DESCRIPTION
While looking at decompress codebase, I stumbled upon a bitshift operation which seems like potential trouble to me:
In the function flat_header, when taking the `len` and `nlen` out of the `hold` variable, the arithmetic right shift (`asr`) is used.
The problem I see there is that if we manage to have a negative hold at some point (very most likely never going to happens, but who knows), we are going to insert some information in the hold.

This might come as a problem when calling the function consume, which codes is using the function `lor`in order to refill the `hold`. Indeed, the introduced `1` bits would not be removed and would corrupt the content of the hold.

I'm pretty sure such a case would never happen (the code would have to fill 31 bits in the hold, which is never done), but keeping this potential corner case when simply replacing `asr` for `lsr` would solve the problem once and for all doesnt seems like the best solution.

This would also allow to consider using `int32` instead of `int` for faster `hold` refilling, in which case, the problem could be a real situation (using boxed `int32` might not be better but preparing for it seems usefull to me).

There might be other awkward uses of asr, but it looked to me like they always were used with positive variables such as lengths.