### PR TITLE
[WIP] Non streamable implementation of RFC 1951

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,9 +1,0 @@
-S lib
-B _build/lib
-
-# Only for testing
-
-S test
-B _build/test
-
-PKG camlzip alcotest re.str cmdliner crowbar

--- a/bench/densld.ml
+++ b/bench/densld.ml
@@ -1,0 +1,26 @@
+open Cmdliner
+open De_landmarks
+
+let w = make_window ~bits:15
+
+let inflate file d =
+  let file = open_in file in
+  let len = in_channel_length file in
+  let src = Bigstringaf.of_string (really_input_string file len) ~off:0 ~len in
+  let dst = Bigstringaf.create (Def.Ns.compress_bound len) in
+  ignore (Def.Ns.deflate ~level:4 ~src ~dst)
+  ; if d then ignore (Inf.Ns.inflate ~src:dst ~dst:src ~w)
+
+let file =
+  let doc = "input file" in
+  Arg.(value & pos 0 string "file" & info [] ~doc)
+
+let d =
+  let doc = "also decompress the input" in
+  Arg.(value & flag & info ["d"] ~doc)
+
+let cmd =
+  ( Term.(const inflate $ file $ d)
+  , Term.info "bench" ~doc:"Run benchmarks for ns implementation" )
+
+let () = Term.(exit @@ eval cmd)

--- a/bench/densld.ml
+++ b/bench/densld.ml
@@ -1,22 +1,23 @@
 open Cmdliner
 open De_landmarks
 
-let w = make_window ~bits:15
-
 let inflate file d =
   let file = open_in file in
   let len = in_channel_length file in
   let src = Bigstringaf.of_string (really_input_string file len) ~off:0 ~len in
-  let dst = Bigstringaf.create (Def.Ns.compress_bound len) in
-  ignore (Def.Ns.deflate ~level:4 ~src ~dst)
-  ; if d then ignore (Inf.Ns.inflate ~src:dst ~dst:src ~w)
+  if d then
+    let dst = Bigstringaf.create (len * 10) in
+    ignore @@ Inf.Ns.inflate ~src ~dst
+  else
+    let dst = Bigstringaf.create (Def.Ns.compress_bound len) in
+    ignore @@ Def.Ns.deflate ~level:4 ~src ~dst
 
 let file =
   let doc = "input file" in
   Arg.(value & pos 0 string "file" & info [] ~doc)
 
 let d =
-  let doc = "also decompress the input" in
+  let doc = "decompress the input" in
   Arg.(value & flag & info ["d"] ~doc)
 
 let cmd =

--- a/bench/densld.ml
+++ b/bench/densld.ml
@@ -7,10 +7,10 @@ let inflate file d =
   let src = Bigstringaf.of_string (really_input_string file len) ~off:0 ~len in
   if d then
     let dst = Bigstringaf.create (len * 10) in
-    ignore @@ Inf.Ns.inflate ~src ~dst
+    ignore @@ Inf.Ns.inflate src dst
   else
     let dst = Bigstringaf.create (Def.Ns.compress_bound len) in
-    ignore @@ Def.Ns.deflate ~level:4 ~src ~dst
+    ignore @@ Def.Ns.deflate src dst
 
 let file =
   let doc = "input file" in

--- a/bench/dune
+++ b/bench/dune
@@ -63,7 +63,8 @@
  (optional)
  (modules de_landmarks)
  (libraries bigarray-compat checkseum optint landmarks de)
- (flags (:standard -w -55))
+ (flags
+  (:standard -w -55))
  (preprocess
   (pps landmarks.ppx --auto)))
 

--- a/bench/dune
+++ b/bench/dune
@@ -63,6 +63,7 @@
  (optional)
  (modules de_landmarks)
  (libraries bigarray-compat checkseum optint landmarks de)
+ (flags (:standard -w -55))
  (preprocess
   (pps landmarks.ppx --auto)))
 

--- a/bench/dune
+++ b/bench/dune
@@ -57,3 +57,22 @@
  (name lzld)
  (modules lzld)
  (libraries decompress.de lz_landmarks))
+
+(library
+ (name de_landmarks)
+ (optional)
+ (modules de_landmarks)
+ (libraries bigarray-compat checkseum optint landmarks de)
+ (preprocess
+  (pps landmarks.ppx --auto)))
+
+(rule
+ (copy ../lib/de.ml de_landmarks.ml))
+
+(rule
+ (copy ../lib/de.mli de_landmarks.mli))
+
+(executable
+ (name densld)
+ (modules densld)
+ (libraries cmdliner de_landmarks bigstringaf))

--- a/bindings/stubs/gen_decompress_bindings.ml
+++ b/bindings/stubs/gen_decompress_bindings.ml
@@ -51,8 +51,7 @@ let deflate i i_len o o_len level =
 let inflate_ns i i_len o o_len =
   let i = bigarray_of_ptr array1 i_len Bigarray.char i in
   let o = bigarray_of_ptr array1 o_len Bigarray.char o in
-  let w = De.make_window ~bits:15 in
-  let res = De.Inf.Ns.inflate ~src:i ~dst:o ~w in
+  let res = De.Inf.Ns.inflate ~src:i ~dst:o in
   match res with Ok (_, res) -> res | Error _ -> invalid_arg "broken"
 
 let deflate_ns i i_len o o_len level =

--- a/bindings/stubs/gen_decompress_bindings.ml
+++ b/bindings/stubs/gen_decompress_bindings.ml
@@ -51,13 +51,13 @@ let deflate i i_len o o_len level =
 let inflate_ns i i_len o o_len =
   let i = bigarray_of_ptr array1 i_len Bigarray.char i in
   let o = bigarray_of_ptr array1 o_len Bigarray.char o in
-  let res = De.Inf.Ns.inflate ~src:i ~dst:o in
+  let res = De.Inf.Ns.inflate i o in
   match res with Ok (_, res) -> res | Error _ -> invalid_arg "broken"
 
 let deflate_ns i i_len o o_len level =
   let i = bigarray_of_ptr array1 i_len Bigarray.char i in
   let o = bigarray_of_ptr array1 o_len Bigarray.char o in
-  De.Def.Ns.deflate ~level ~src:i ~dst:o
+  De.Def.Ns.deflate ~level i o
 
 module Stubs (I : Cstubs_inverted.INTERNAL) = struct
   let () =

--- a/bindings/stubs/gen_decompress_bindings.ml
+++ b/bindings/stubs/gen_decompress_bindings.ml
@@ -48,6 +48,18 @@ let deflate i i_len o o_len level =
   let encoder = Zl.Def.dst encoder o 0 o_len in
   go encoder
 
+let inflate_ns i i_len o o_len =
+  let i = bigarray_of_ptr array1 i_len Bigarray.char i in
+  let o = bigarray_of_ptr array1 o_len Bigarray.char o in
+  let w = De.make_window ~bits:15 in
+  let res = De.Inf.Ns.inflate ~src:i ~dst:o ~w in
+  match res with Ok (_, res) -> res | Error _ -> invalid_arg "broken"
+
+let deflate_ns i i_len o o_len level =
+  let i = bigarray_of_ptr array1 i_len Bigarray.char i in
+  let o = bigarray_of_ptr array1 o_len Bigarray.char o in
+  De.Def.Ns.deflate ~level ~src:i ~dst:o
+
 module Stubs (I : Cstubs_inverted.INTERNAL) = struct
   let () =
     I.internal "decompress_inflate"
@@ -58,4 +70,14 @@ module Stubs (I : Cstubs_inverted.INTERNAL) = struct
     I.internal "decompress_deflate"
       (ptr char @-> int @-> ptr char @-> int @-> int @-> returning int)
       deflate
+
+  let () =
+    I.internal "decompress_ns_inflate"
+      (ptr char @-> int @-> ptr char @-> int @-> returning int)
+      inflate_ns
+
+  let () =
+    I.internal "decompress_ns_deflate"
+      (ptr char @-> int @-> ptr char @-> int @-> int @-> returning int)
+      deflate_ns
 end

--- a/bindings/stubs/gen_decompress_bindings.ml
+++ b/bindings/stubs/gen_decompress_bindings.ml
@@ -57,7 +57,8 @@ let inflate_ns i i_len o o_len =
 let deflate_ns i i_len o o_len level =
   let i = bigarray_of_ptr array1 i_len Bigarray.char i in
   let o = bigarray_of_ptr array1 o_len Bigarray.char o in
-  De.Def.Ns.deflate ~level i o
+  let res = De.Def.Ns.deflate ~level i o in
+  match res with Ok res -> res | Error _ -> invalid_arg "broken"
 
 module Stubs (I : Cstubs_inverted.INTERNAL) = struct
   let () =

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -6,4 +6,4 @@
 (executable
  (name fuzz_ns)
  (modules fuzz_ns)
- (libraries fmt bigstringaf camlzip checkseum.c de crowbar))
+ (libraries rresult fmt bigstringaf camlzip checkseum.c de crowbar))

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,3 +1,9 @@
 (executable
  (name fuzz)
+ (modules fuzz)
+ (libraries fmt bigstringaf camlzip checkseum.c de crowbar))
+
+(executable
+ (name fuzz_ns)
+ (modules fuzz_ns)
  (libraries fmt bigstringaf camlzip checkseum.c de crowbar))

--- a/fuzz/fuzz_ns.ml
+++ b/fuzz/fuzz_ns.ml
@@ -54,9 +54,9 @@ let () =
   let len = String.length input in
   Bigstringaf.blit_from_string input ~src_off:0 i ~dst_off:0 ~len
   ; let src_def = Bigstringaf.sub i ~off:0 ~len in
-    let res = Def.Ns.deflate ~level:4 ~src:src_def ~dst:o in
+    let res = Def.Ns.deflate src_def o in
     let src_inf = Bigstringaf.sub o ~off:0 ~len:res in
-    let res = Inf.Ns.inflate ~src:src_inf ~dst:i ~w in
+    let res = Inf.Ns.inflate src_inf i in
     match res with
     | Ok (_, res) ->
       let output = Bigstringaf.sub i ~off:0 ~len:res in

--- a/fuzz/fuzz_ns.ml
+++ b/fuzz/fuzz_ns.ml
@@ -1,0 +1,66 @@
+open De
+
+let w = make_window ~bits:15
+let i = bigstring_create 1024
+let o = bigstring_create (Def.Ns.compress_bound 1024)
+
+let pp_chr =
+  Fmt.using (function '\032' .. '\126' as x -> x | _ -> '.') Fmt.char
+
+let pp_scalar :
+    type buffer.
+    get:(buffer -> int -> char) -> length:(buffer -> int) -> buffer Fmt.t =
+ fun ~get ~length ppf b ->
+  let l = length b in
+  for i = 0 to l / 16 do
+    Fmt.pf ppf "%08x: " (i * 16)
+    ; let j = ref 0 in
+      while !j < 16 do
+        if (i * 16) + !j < l then
+          Fmt.pf ppf "%02x" (Char.code @@ get b ((i * 16) + !j))
+        else Fmt.pf ppf "  "
+        ; if !j mod 2 <> 0 then Fmt.pf ppf " "
+        ; incr j
+      done
+      ; Fmt.pf ppf "  "
+      ; j := 0
+      ; while !j < 16 do
+          if (i * 16) + !j < l then
+            Fmt.pf ppf "%a" pp_chr (get b ((i * 16) + !j))
+          else Fmt.pf ppf " "
+          ; incr j
+        done
+      ; Fmt.pf ppf "@\n"
+  done
+
+let pp_string = pp_scalar ~get:String.get ~length:String.length
+let ( >>= ) = Crowbar.dynamic_bind
+let ( <.> ) f g x = f (g x)
+
+let non_empty_bytes n : string Crowbar.gen =
+  let open Crowbar in
+  let ( >>= ) = dynamic_bind in
+
+  let rec go acc = function
+    | 0 -> concat_gen_list (const "") acc
+    | n -> go (map [uint8] (String.make 1 <.> Char.chr) :: acc) (pred n) in
+  let gen n = go [] n in
+
+  range n >>= (gen <.> succ)
+
+let () =
+  Crowbar.add_test ~name:"compress ns/uncompress ns" [non_empty_bytes 1024]
+  @@ fun input ->
+  let len = String.length input in
+  Bigstringaf.blit_from_string input ~src_off:0 i ~dst_off:0 ~len
+  ; let src_def = Bigstringaf.sub i ~off:0 ~len in
+    let res = Def.Ns.deflate ~level:4 ~src:src_def ~dst:o in
+    let src_inf = Bigstringaf.sub o ~off:0 ~len:res in
+    let res = Inf.Ns.inflate ~src:src_inf ~dst:i ~w in
+    match res with
+    | Ok (_, res) ->
+      let output = Bigstringaf.sub i ~off:0 ~len:res in
+      Crowbar.check_eq ~eq:String.equal ~pp:pp_string ~cmp:String.compare
+        (Bigstringaf.to_string output)
+        input
+    | Error _err -> Crowbar.fail "iso fail"

--- a/fuzz/fuzz_ns.ml
+++ b/fuzz/fuzz_ns.ml
@@ -55,6 +55,7 @@ let () =
   Bigstringaf.blit_from_string input ~src_off:0 i ~dst_off:0 ~len
   ; let src_def = Bigstringaf.sub i ~off:0 ~len in
     let res = Def.Ns.deflate src_def o in
+    let res = Rresult.R.get_ok res in
     let src_inf = Bigstringaf.sub o ~off:0 ~len:res in
     let res = Inf.Ns.inflate src_inf i in
     match res with

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1474,13 +1474,13 @@ module Inf = struct
 
     let pp_error ppf e =
       let s = match e with
-      | Unexpected_end_of_input      -> "Unexpected_end_of_input"
-      | Unexpected_end_of_output     -> "Unexpected_end_of_output"
-      | Invalid_kind_of_block        -> "Invalid_kind_of_block"
-      | Invalid_dictionary           -> "Invalid_dictionary"
-      | Invalid_complement_of_length -> "Invalid_complement_of_length"
-      | Invalid_distance             -> "Invalid_distance"
-      | Invalid_distance_code        -> "Invalid_distance_code"
+      | Unexpected_end_of_input      -> "Unexpected end of input"
+      | Unexpected_end_of_output     -> "Unexpected end of output"
+      | Invalid_kind_of_block        -> "Invalid kind of block"
+      | Invalid_dictionary           -> "Invalid dictionary"
+      | Invalid_complement_of_length -> "Invalid complement of length"
+      | Invalid_distance             -> "Invalid distance"
+      | Invalid_distance_code        -> "Invalid distance code"
       in
       Format.fprintf ppf "%s" s
 

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1738,7 +1738,7 @@ module Inf = struct
         | 2 -> dynamic d
         | 3 -> err_invalid_kind_of_block ()
         | _ -> assert false)
-        ; if last then () else decode d
+        ; if last then d.i_pos <- d.i_pos - (d.bits lsr 3) else decode d
 
     let inflate src dst =
       let d =

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -224,21 +224,20 @@ let zigzag =
 
 let _length =
   [|
-     0; 0; 0; 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12
-   ; 12; 13; 13; 13; 13; 14; 14; 14; 14; 15; 15; 15; 15; 16; 16; 16; 16; 16
-   ; 16; 16; 16; 17; 17; 17; 17; 17; 17; 17; 17; 18; 18; 18; 18; 18; 18; 18
-   ; 18; 19; 19; 19; 19; 19; 19; 19; 19; 20; 20; 20; 20; 20; 20; 20; 20; 20
-   ; 20; 20; 20; 20; 20; 20; 20; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21
-   ; 21; 21; 21; 21; 21; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22
-   ; 22; 22; 22; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23
-   ; 23; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24
-   ; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 25; 25; 25
-   ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25
-   ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 26; 26; 26; 26; 26; 26; 26
-   ; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26
-   ; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
-   ; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
-   ; 27; 27; 28
+     0; 0; 0; 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12
+   ; 13; 13; 13; 13; 14; 14; 14; 14; 15; 15; 15; 15; 16; 16; 16; 16; 16; 16; 16
+   ; 16; 17; 17; 17; 17; 17; 17; 17; 17; 18; 18; 18; 18; 18; 18; 18; 18; 19; 19
+   ; 19; 19; 19; 19; 19; 19; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20
+   ; 20; 20; 20; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21
+   ; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 23; 23; 23
+   ; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 24; 24; 24; 24; 24; 24
+   ; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24
+   ; 24; 24; 24; 24; 24; 24; 24; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25
+   ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25
+   ; 25; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26
+   ; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27
+   ; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
+   ; 27; 27; 27; 27; 27; 27; 27; 28
   |]
 
 let _distance =
@@ -1460,7 +1459,6 @@ module Inf = struct
       ; o: bigstring
       ; mutable o_pos: int
       ; o_len: int
-      ; w: WInf.t
     }
 
     (* errors. *)
@@ -1495,18 +1493,59 @@ module Inf = struct
       raise (Malformed Unexpected_end_of_output)
 
     let err_invalid_kind_of_block () = raise (Malformed Invalid_kind_of_block)
-
     let err_invalid_dictionary () = raise (Malformed Invalid_dictionary)
 
     let err_invalid_complement_of_length () =
       raise (Malformed Invalid_complement_of_length)
 
     let err_invalid_distance () = raise (Malformed Invalid_distance)
-
     let err_invalid_distance_code () = raise (Malformed Invalid_distance_code)
 
     (* remaining bytes to read [d.i]. *)
     let i_rem d = d.i_len - d.i_pos [@@inline]
+
+    let _slow_blit src src_off dst dst_off len =
+      for i = 0 to len - 1 do
+        let v = unsafe_get_uint8 src (src_off + i) in
+        unsafe_set_uint8 dst (dst_off + i) v
+      done
+
+    let _blit src src_off dst dst_off len =
+      if dst_off - src_off < 4 then _slow_blit src src_off dst dst_off len
+      else
+        let len0 = len land 3 in
+        let len1 = len asr 2 in
+
+        for i = 0 to len1 - 1 do
+          let i = i * 4 in
+          let v = unsafe_get_uint32 src (src_off + i) in
+          unsafe_set_uint32 dst (dst_off + i) v
+        done
+
+        ; for i = 0 to len0 - 1 do
+            let i = (len1 * 4) + i in
+            let v = unsafe_get_uint8 src (src_off + i) in
+            unsafe_set_uint8 dst (dst_off + i) v
+          done
+
+    let _fill v dst dst_off len =
+      let len0 = len land 3 in
+      let len1 = len asr 2 in
+
+      let nv = Nativeint.of_int v in
+      let vv = Nativeint.(logor (shift_left nv 8) nv) in
+      let vvvv = Nativeint.(logor (shift_left vv 16) vv) in
+      let vvvv = Nativeint.to_int32 vvvv in
+
+      for i = 0 to len1 - 1 do
+        let i = i * 4 in
+        unsafe_set_uint32 dst (dst_off + i) vvvv
+      done
+
+      ; for i = 0 to len0 - 1 do
+          let i = (len1 * 4) + i in
+          unsafe_set_uint8 dst (dst_off + i) v
+        done
 
     let flat d =
       d.i_pos <- d.i_pos - (d.bits / 8)
@@ -1520,28 +1559,36 @@ module Inf = struct
           else (
             if len > i_rem d then err_unexpected_end_of_input ()
             ; if len > d.o_len - d.o_pos then err_unexpected_end_of_output ()
-            ; WInf.blit d.w d.i d.i_pos d.o d.o_pos len
+            ; _blit d.i d.i_pos d.o d.o_pos len
             ; d.o_pos <- d.o_pos + len
             ; d.i_pos <- d.i_pos + len)
 
-    let _fill_bits d =
-      let rem = i_rem d in
-      if rem > 1 then (
-        d.hold <- d.hold lor (unsafe_get_uint16 d.i d.i_pos lsl d.bits)
-        ; d.i_pos <- d.i_pos + 2
-        ; d.bits <- d.bits + 16)
-      else
-        if rem = 1 then (
+    let _fill_bits d n =
+      if d.bits < n then
+        let rem = i_rem d in
+        if rem > 1 then (
+          d.hold <- d.hold lor (unsafe_get_uint16 d.i d.i_pos lsl d.bits)
+          ; d.i_pos <- d.i_pos + 2
+          ; d.bits <- d.bits + 16)
+        else if rem = 1 then (
           d.hold <- d.hold lor (unsafe_get_uint8 d.i d.i_pos lsl d.bits)
           ; d.i_pos <- d.i_pos + 1
           ; d.bits <- d.bits + 8)
         else err_unexpected_end_of_input ()
-          [@@inline]
+      [@@inline]
 
-    (* clecat: Removed the rec flag on fill_bits, as it was never called with
-       d greater than 16. However, we should make sure that it is never done in
-       the future. *)
-    let fill_bits d n = if d.bits < n then _fill_bits d
+    let __fill_bits d n =
+      if d.bits < n then
+        let rem = i_rem d in
+        if rem > 1 then (
+          d.hold <- d.hold lor (unsafe_get_uint16 d.i d.i_pos lsl d.bits)
+          ; d.i_pos <- d.i_pos + 2
+          ; d.bits <- d.bits + 16)
+        else if rem = 1 then (
+          d.hold <- d.hold lor (unsafe_get_uint8 d.i d.i_pos lsl d.bits)
+          ; d.i_pos <- d.i_pos + 1
+          ; d.bits <- d.bits + 8)
+      [@@inline]
 
     let pop_bits d n =
       let v = d.hold land ((1 lsl n) - 1) in
@@ -1555,17 +1602,9 @@ module Inf = struct
     exception Invalid_distance_code
 
     let inflate lit dist d =
-      let fill_bits d lit n =
-        if
-          d.bits < n
-          && not
-               (lit.Lookup.t.(d.hold land lit.Lookup.m) land Lookup.mask == 256
-               && lit.Lookup.t.(d.hold land lit.Lookup.m) lsr 15 <= d.bits
-               && i_rem d < 1)
-        then _fill_bits d in
       try
-        let rec length () =
-          fill_bits d lit lit.Lookup.l
+        let rec inflate_loop () =
+          __fill_bits d lit.Lookup.l
           ; let value =
               lit.Lookup.t.(d.hold land lit.Lookup.m) land Lookup.mask in
             let len = lit.Lookup.t.(d.hold land lit.Lookup.m) lsr 15 in
@@ -1573,48 +1612,36 @@ module Inf = struct
             ; d.bits <- d.bits - len
             ; if value < 256 then (
                 unsafe_set_uint8 d.o d.o_pos value
-                ; WInf.add d.w value
                 ; d.o_pos <- d.o_pos + 1
-                ; length ())
+                ; inflate_loop ())
               else if value == 256 then raise_notrace End
-              else extra_length (value - 257)
-        and extra_length l =
-          let len = _extra_lbits.(l) in
-          fill_bits d lit len
-          ; let extra = pop_bits d len in
-            distance (_base_length.(l land 0x1f) + 3 + extra)
-        and distance l =
-          fill_bits d lit dist.Lookup.l
-          ; let value =
-              dist.Lookup.t.(d.hold land dist.Lookup.m) land Lookup.mask in
-            let len = dist.Lookup.t.(d.hold land dist.Lookup.m) lsr 15 in
-            d.hold <- d.hold lsr len
-            ; d.bits <- d.bits - len
-            ; extra_distance l value
-        and extra_distance l d_ =
-          let len = _extra_dbits.(d_ land 0x1f) in
-          fill_bits d lit len
-          ; let extra = pop_bits d len in
-            write l (_base_dist.(d_) + 1 + extra)
-        and write l d_ =
-          if d_ == 0 then raise_notrace Invalid_distance_code
-          ; if d_ > WInf.have d.w then raise_notrace Invalid_distance
-          ; let len = min l (d.o_len - d.o_pos) in
-            let off = WInf.mask (d.w.WInf.w - d_) in
-            (if d_ == 1 then
-             let v = unsafe_get_uint8 d.w.WInf.raw off in
-             WInf.fill d.w v d.o d.o_pos len
-            else
-              let off = WInf.mask (d.w.WInf.w - d_) in
-              let pre = WInf.max - off in
-              let rst = len - pre in
-              if rst > 0 then (
-                WInf.blit d.w d.w.WInf.raw off d.o d.o_pos pre
-                ; WInf.blit d.w d.w.WInf.raw 0 d.o (d.o_pos + pre) rst)
-              else WInf.blit d.w d.w.WInf.raw off d.o d.o_pos len)
-            ; d.o_pos <- d.o_pos + len
-              ; if l - len == 0 then length () in
-        length ()
+              else
+                let l = value - 257 in
+                let len = _extra_lbits.(l) in
+                __fill_bits d len
+                ; let extra = pop_bits d len in
+                  let l = _base_length.(l land 0x1f) + 3 + extra in
+                  __fill_bits d dist.Lookup.l
+                  ; let value =
+                      dist.Lookup.t.(d.hold land dist.Lookup.m) land Lookup.mask
+                    in
+                    let len = dist.Lookup.t.(d.hold land dist.Lookup.m) lsr 15 in
+                    d.hold <- d.hold lsr len
+                    ; d.bits <- d.bits - len
+                    ; let d_ = value in
+                      let len = _extra_dbits.(d_ land 0x1f) in
+                      __fill_bits d len
+                      ; let extra = pop_bits d len in
+                        let d_ = _base_dist.(d_) + 1 + extra in
+                        if d_ == 0 then raise_notrace Invalid_distance_code
+                        ; if d_ > min d.o_pos (1 lsl 15) then
+                            raise_notrace Invalid_distance
+                        ; let len = min l (d.o_len - d.o_pos) in
+                          let off = d.o_pos - d_ in
+                          _blit d.o off d.o d.o_pos len
+                          ; d.o_pos <- d.o_pos + len
+                          ; if l - len == 0 then inflate_loop () in
+        inflate_loop ()
       with
       | End -> ()
       | Invalid_distance -> err_invalid_distance ()
@@ -1643,13 +1670,13 @@ module Inf = struct
       let max_res = hlit + hdist in
       let mask = (1 lsl max_bits) - 1 in
       let get d =
-        fill_bits d max_bits
+        _fill_bits d max_bits
         ; let v = t.(d.hold land mask) land Lookup.mask in
           let len = t.(d.hold land mask) lsr 15 in
           d.hold <- d.hold lsr len
           ; d.bits <- d.bits - len
           ; v in
-      let get_bits d n = fill_bits d n ; pop_bits d n in
+      let get_bits d n = _fill_bits d n ; pop_bits d n in
       let ret r d = make_table r hlit hdist d in
       let rec record i copy len d =
         if i + copy > max_res then err_invalid_dictionary ()
@@ -1682,7 +1709,7 @@ module Inf = struct
       let res = Array.make 19 0 in
 
       while !i < hclen do
-        fill_bits d 3
+        _fill_bits d 3
         ; let code = pop_bits d 3 in
           res.(zigzag.(!i)) <- code
           ; incr i
@@ -1695,14 +1722,14 @@ module Inf = struct
         with Invalid_huffman -> err_invalid_dictionary ()
 
     let dynamic d =
-      fill_bits d 14
+      _fill_bits d 14
       ; let hlit = pop_bits d 5 + 257 in
         let hdist = pop_bits d 5 + 1 in
         let hclen = pop_bits d 4 + 4 in
         table d hlit hdist hclen
 
     let rec decode d =
-      fill_bits d 3
+      _fill_bits d 3
       ; let last = pop_bits d 1 == 1 in
         let block_type = pop_bits d 2 in
         (match block_type with
@@ -1711,9 +1738,9 @@ module Inf = struct
         | 2 -> dynamic d
         | 3 -> err_invalid_kind_of_block ()
         | _ -> assert false)
-        ; if last then WInf.tail d.w else decode d
+        ; if last then () else decode d
 
-    let inflate ~src ~dst ~w =
+    let inflate ~src ~dst =
       let d =
         {
           i= src
@@ -1724,7 +1751,6 @@ module Inf = struct
         ; o_len= bigstring_length dst
         ; hold= 0
         ; bits= 0
-        ; w= WInf.from w
         } in
       try
         decode d
@@ -2320,8 +2346,7 @@ module Def = struct
     | `Copy (off, len), Dynamic dynamic ->
       (* assert (len >= 3 && len <= 255 + 3) ; *)
       (* assert (off >= 1 && off <= 32767 + 1) ; *)
-      dynamic.ltree.T.tree.Lookup.t.(256 + 1 + _length.(len)) lsr _max_bits
-      > 0
+      dynamic.ltree.T.tree.Lookup.t.(256 + 1 + _length.(len)) lsr _max_bits > 0
       && dynamic.dtree.T.tree.Lookup.t.(_distance (pred off)) lsr _max_bits > 0
     | `End, (Fixed | Dynamic _) | `Literal _, (Flat _ | Fixed) | `Copy _, Fixed
       ->
@@ -3070,7 +3095,8 @@ module Def = struct
         let m, n = ref 0, ref 0 in
         if
           !i <> sym_count
-          && (b = e || a.(!i) lsr _num_symbol_bits <= a.(!b) lsr _num_symbol_bits)
+          && (b = e
+             || a.(!i) lsr _num_symbol_bits <= a.(!b) lsr _num_symbol_bits)
         then (
           m := !i
           ; incr i)
@@ -3107,7 +3133,8 @@ module Def = struct
             let parent_depth = a.(parent) lsr _num_symbol_bits in
             let depth = parent_depth + 1 in
             let len = ref depth in
-            a.(node) <- a.(node) land _symbol_mask lor (depth lsl _num_symbol_bits)
+            a.(node) <-
+              a.(node) land _symbol_mask lor (depth lsl _num_symbol_bits)
             ; if !len >= max_codeword then (
                 len := max_codeword - 1
                 ; while len_counts.(!len) == 0 do
@@ -3363,8 +3390,7 @@ module Def = struct
         ; let rec h num_explicit_lens =
             if
               _num_precode_syms < 5
-              || c.precode_lens.(zigzag.(num_explicit_lens - 1))
-                 <> 0
+              || c.precode_lens.(zigzag.(num_explicit_lens - 1)) <> 0
             then c.num_explicit_lens <- num_explicit_lens
             else h (num_explicit_lens - 1) in
           h _num_precode_syms
@@ -3767,12 +3793,14 @@ module Def = struct
       let next_hash = ref 0 in
       let hc_mf = hc_matchfinder_init () in
       let seq_len =
-        ((_soft_max_block_length + _min_match_len - 1) / _min_match_len) + 1 in
+        ((_soft_max_block_length + _min_match_len - 1) / _min_match_len) + 1
+      in
       let s = {seqs= Array.init seq_len init_sequence; pos= 0} in
       while os.i_pos <> os.i_len do
         let in_block_begin = ref os.i_pos in
         let in_max_block_end =
-          ref (os.i_pos + min (os.i_len - os.i_pos) _soft_max_block_length) in
+          ref (os.i_pos + min (os.i_len - os.i_pos) _soft_max_block_length)
+        in
         let litrunlen = ref 0 in
         s.pos <- 0
         ; init_block_split_stats split_stats
@@ -3875,7 +3903,8 @@ module Def = struct
               } )
 
     let compress_bound len =
-      let max_blocks = max 1 ((len + _min_block_length - 1) / _min_block_length) in
+      let max_blocks =
+        max 1 ((len + _min_block_length - 1) / _min_block_length) in
       (5 * max_blocks) + len + 1 + _end_padding
 
     let deflate ?(level = 4) ~src ~dst =

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -224,20 +224,21 @@ let zigzag =
 
 let _length =
   [|
-     0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12; 12; 13; 13
-   ; 13; 13; 14; 14; 14; 14; 15; 15; 15; 15; 16; 16; 16; 16; 16; 16; 16; 16; 17
-   ; 17; 17; 17; 17; 17; 17; 17; 18; 18; 18; 18; 18; 18; 18; 18; 19; 19; 19; 19
-   ; 19; 19; 19; 19; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20; 20
-   ; 20; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 22; 22
-   ; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 23; 23; 23; 23; 23
-   ; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 24; 24; 24; 24; 24; 24; 24; 24
-   ; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24
-   ; 24; 24; 24; 24; 24; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25
-   ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 26
-   ; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26
-   ; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27; 27; 27
-   ; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
-   ; 27; 27; 27; 27; 27; 28
+     0; 0; 0; 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12
+   ; 12; 13; 13; 13; 13; 14; 14; 14; 14; 15; 15; 15; 15; 16; 16; 16; 16; 16
+   ; 16; 16; 16; 17; 17; 17; 17; 17; 17; 17; 17; 18; 18; 18; 18; 18; 18; 18
+   ; 18; 19; 19; 19; 19; 19; 19; 19; 19; 20; 20; 20; 20; 20; 20; 20; 20; 20
+   ; 20; 20; 20; 20; 20; 20; 20; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21
+   ; 21; 21; 21; 21; 21; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22
+   ; 22; 22; 22; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23
+   ; 23; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24
+   ; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 25; 25; 25
+   ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25
+   ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 26; 26; 26; 26; 26; 26; 26
+   ; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26
+   ; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
+   ; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
+   ; 27; 27; 28
   |]
 
 let _distance =
@@ -2234,8 +2235,8 @@ let succ_literal literals chr =
 
 let succ_length literals length =
   assert (length >= 3 && length <= 255 + 3)
-  ; literals.(256 + 1 + _length.(length - 3)) <-
-      literals.(256 + 1 + _length.(length - 3)) + 1
+  ; literals.(256 + 1 + _length.(length)) <-
+      literals.(256 + 1 + _length.(length)) + 1
 
 let make_distances () = Array.make ((2 * _d_codes) + 1) 0
 
@@ -2315,7 +2316,7 @@ module Def = struct
     | `Copy (off, len), Dynamic dynamic ->
       (* assert (len >= 3 && len <= 255 + 3) ; *)
       (* assert (off >= 1 && off <= 32767 + 1) ; *)
-      dynamic.ltree.T.tree.Lookup.t.(256 + 1 + _length.(len - 3)) lsr _max_bits
+      dynamic.ltree.T.tree.Lookup.t.(256 + 1 + _length.(len)) lsr _max_bits
       > 0
       && dynamic.dtree.T.tree.Lookup.t.(_distance (pred off)) lsr _max_bits > 0
     | `End, (Fixed | Dynamic _) | `Literal _, (Flat _ | Fixed) | `Copy _, Fixed
@@ -2649,7 +2650,7 @@ module Def = struct
                [flush_bits] can be reached with [news] Calgary file. *)
             let off, len = cmd land 0xffff, (cmd lsr 16) land 0x1ff in
 
-            let code = _length.(len) in
+            let code = _length.(len + 3) in
             let len0, v0 = Lookup.get ltree (code + 256 + 1) in
             let len1, v1 =
               _extra_lbits.(code), len - _base_length.(code land 0x1f) in
@@ -3021,49 +3022,6 @@ module Def = struct
       ; bits= 0
       }
 
-    let length_slot_base =
-      [|
-         3; 4; 5; 6; 7; 8; 9; 10; 11; 13; 15; 17; 19; 23; 27; 31; 35; 43; 51; 59
-       ; 67; 83; 99; 115; 131; 163; 195; 227; 258
-      |]
-
-    let extra_length_bits =
-      [|
-         0; 0; 0; 0; 0; 0; 0; 0; 1; 1; 1; 1; 2; 2; 2; 2; 3; 3; 3; 3; 4; 4; 4; 4
-       ; 5; 5; 5; 5; 0
-      |]
-
-    let offset_slot_base =
-      [|
-         1; 2; 3; 4; 5; 7; 9; 13; 17; 25; 33; 49; 65; 97; 129; 193; 257; 385; 513
-       ; 769; 1025; 1537; 2049; 3073; 4097; 6145; 8193; 12289; 16385; 24577
-      |]
-
-    let extra_offset_bits =
-      [|
-         0; 0; 0; 0; 1; 1; 2; 2; 3; 3; 4; 4; 5; 5; 6; 6; 7; 7; 8; 8; 9; 9; 10; 10
-       ; 11; 11; 12; 12; 13; 13
-      |]
-
-    let length_slot =
-      [|
-         0; 0; 0; 0; 1; 2; 3; 4; 5; 6; 7; 8; 8; 9; 9; 10; 10; 11; 11; 12; 12; 12
-       ; 12; 13; 13; 13; 13; 14; 14; 14; 14; 15; 15; 15; 15; 16; 16; 16; 16; 16
-       ; 16; 16; 16; 17; 17; 17; 17; 17; 17; 17; 17; 18; 18; 18; 18; 18; 18; 18
-       ; 18; 19; 19; 19; 19; 19; 19; 19; 19; 20; 20; 20; 20; 20; 20; 20; 20; 20
-       ; 20; 20; 20; 20; 20; 20; 20; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21; 21
-       ; 21; 21; 21; 21; 21; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22; 22
-       ; 22; 22; 22; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23; 23
-       ; 23; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24
-       ; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 24; 25; 25; 25
-       ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25
-       ; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 25; 26; 26; 26; 26; 26; 26; 26
-       ; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26; 26
-       ; 26; 26; 26; 26; 26; 26; 26; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
-       ; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27; 27
-       ; 27; 27; 28
-      |]
-
     let get_num_counter num_syms = (num_syms + (3 / 4) + 3) land lnot 3
 
     let sort_symbols num_syms freqs lens symout =
@@ -3241,9 +3199,9 @@ module Def = struct
       ; make_huffman_codes freqs static_codes
 
     let init_offset_slot_fast offset_slot_fast =
-      for offset_slot = 0 to Array.length offset_slot_base - 1 do
-        let offset = offset_slot_base.(offset_slot) in
-        let offset_end = offset + (1 lsl extra_offset_bits.(offset_slot)) in
+      for offset_slot = 0 to Array.length _base_dist - 3 do
+        let offset = _base_dist.(offset_slot) + 1 in
+        let offset_end = offset + (1 lsl _extra_dbits.(offset_slot)) in
         for i = offset to offset_end - 1 do
           offset_slot_fast.(i) <- offset_slot
         done
@@ -3317,12 +3275,8 @@ module Def = struct
       write_uncompressed_blocks os os.o_len true
       ; flush_output os
 
-    let precode_lens_permutation =
-      [|16; 17; 18; 0; 8; 7; 9; 6; 10; 5; 11; 4; 12; 3; 13; 2; 14; 1; 15|]
-
     let compute_precode_items lens num_lens precode_freqs precode_items =
       Array.fill precode_freqs 0 (Array.length precode_freqs) 0
-
       ; let itemptr = ref 0 in
         let run_start = ref 0 in
         let rec f () =
@@ -3404,7 +3358,7 @@ module Def = struct
         ; let rec h num_explicit_lens =
             if
               num_precode_syms < 5
-              || c.precode_lens.(precode_lens_permutation.(num_explicit_lens - 1))
+              || c.precode_lens.(zigzag.(num_explicit_lens - 1))
                  <> 0
             then c.num_explicit_lens <- num_explicit_lens
             else h (num_explicit_lens - 1) in
@@ -3430,7 +3384,7 @@ module Def = struct
       ; add_bits os (c.num_explicit_lens - 4) 4
       ; flush_bits os
       ; for i = 0 to c.num_explicit_lens - 1 do
-          add_bits os c.precode_lens.(precode_lens_permutation.(i)) 3
+          add_bits os c.precode_lens.(zigzag.(i)) 3
           ; flush_bits os
         done
       ; for i = 0 to c.num_precode_items - 1 do
@@ -3503,8 +3457,8 @@ module Def = struct
                 codes.codewords.litlen.(litlen_symbol)
                 codes.lens.litlen.(litlen_symbol)
               ; add_bits os
-                  (length - length_slot_base.(length_slot))
-                  extra_length_bits.(length_slot)
+                  (length - _base_length.(length_slot) - 3)
+                  _extra_lbits.(length_slot)
               ; if
                   max_litlen_codeword_len
                   + max_extra_length_bits
@@ -3519,8 +3473,8 @@ module Def = struct
                 ; if max_offset_codeword_len + max_extra_offset_bits <= 1 then
                     flush_bits os
                 ; add_bits os
-                    (sequences.(seq).offset - offset_slot_base.(offset_symbol))
-                    extra_offset_bits.(offset_symbol)
+                    (sequences.(seq).offset - _base_dist.(offset_symbol) - 1)
+                    _extra_dbits.(offset_symbol)
                 ; flush_bits os
                 ; f (seq + 1)) in
       f 0
@@ -3569,8 +3523,8 @@ module Def = struct
         done
       ; dynamic_cost := !dynamic_cost + c.codes.lens.litlen.(256)
       ; static_cost := !static_cost + 7
-      ; for sym = 257 to 257 + Array.length extra_length_bits - 1 do
-          let extra = extra_length_bits.(sym - 257) in
+      ; for sym = 257 to 257 + Array.length _extra_lbits - 3 do
+          let extra = _extra_lbits.(sym - 257) in
           dynamic_cost :=
             !dynamic_cost
             + (c.freqs.litlen.(sym) * (extra + c.codes.lens.litlen.(sym)))
@@ -3579,8 +3533,8 @@ module Def = struct
               + c.freqs.litlen.(sym)
                 * (extra + c.static_codes.lens.litlen.(sym))
         done
-      ; for sym = 0 to Array.length extra_offset_bits - 1 do
-          let extra = extra_offset_bits.(sym) in
+      ; for sym = 0 to Array.length _extra_dbits - 3 do
+          let extra = _extra_dbits.(sym) in
           dynamic_cost :=
             !dynamic_cost
             + (c.freqs.offset.(sym) * (extra + c.codes.lens.offset.(sym)))
@@ -3777,7 +3731,7 @@ module Def = struct
       ; incr litrunlen
 
     let choose_match c length offset litrunlen s =
-      let length_slot = length_slot.(length) in
+      let length_slot = _length.(length) in
       let offset_slot = c.offset_slot_fast.(offset) in
       c.freqs.litlen.(257 + length_slot) <-
         succ c.freqs.litlen.(257 + length_slot)
@@ -4123,8 +4077,8 @@ module Lz77 = struct
       ; res
 
   let succ_length literals length =
-    literals.(256 + 1 + _length.(length - 3)) <-
-      literals.(256 + 1 + _length.(length - 3)) + 1
+    literals.(256 + 1 + _length.(length)) <-
+      literals.(256 + 1 + _length.(length)) + 1
 
   let succ_distance distances distance =
     distances.(_distance (pred distance)) <-

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1448,7 +1448,7 @@ module Inf = struct
     ; d.k <- decode_k
     ; WInf.reset d.w
 
-  module Non_streamable = struct
+  module Ns = struct
     type decoder =
       { i: bigstring
       ; mutable i_pos : int

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -3887,12 +3887,10 @@ module Def = struct
             let os = init_output src dst in
             write_uncompressed_block os (os.i_len - os.i_pos) true
             ; flush_output os)
-          else impl c src dst
-        in
+          else impl c src dst in
         Ok res
       with Malformed e -> Error e
-
-    end
+  end
 end
 
 module Lz77 = struct

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -3084,7 +3084,7 @@ module Def = struct
           let to_sort = Array.sub symout counters_pos counters_len in
           Array.sort
             (fun i j ->
-              match i, j with 0, _ -> 1 | _, 0 -> -1 | _ -> Int.compare i j)
+              match i, j with 0, _ -> 1 | _, 0 -> -1 | _ -> i - j)
             to_sort
           ; Array.blit to_sort 0 symout counters_pos counters_len
           ; !num_used_syms

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -2121,24 +2121,24 @@ module Queue = struct
   exception Empty
 
   let push_exn t v =
-    if (full) t then raise Full
-    ; unsafe_set t.buf ((mask) t t.w) v
+    if (full [@inlined]) t then raise Full
+    ; unsafe_set t.buf ((mask [@inlined]) t t.w) v
     ; t.w <- t.w + 1
 
   let pop_exn t =
-    if (empty) t then raise Empty
-    ; let r = unsafe_get t.buf ((mask) t t.r) in
+    if (empty [@inlined]) t then raise Empty
+    ; let r = unsafe_get t.buf ((mask [@inlined]) t t.r) in
       t.r <- t.r + 1
       ; r
 
   let peek_exn t =
-    if (empty) t then raise Empty
-    ; unsafe_get t.buf ((mask) t t.r)
+    if (empty [@inlined]) t then raise Empty
+    ; unsafe_get t.buf ((mask [@inlined]) t t.r)
 
   let unsafe_junk t = t.r <- t.r + 1
 
   let junk_exn t n =
-    if (size) t < n then
+    if (size [@inlined]) t < n then
       invalid_arg "You want to junk more than what we have"
     ; t.r <- t.r + n
 

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -3260,7 +3260,7 @@ module Def = struct
       end
 
     let write_block_header os is_final_block block_type =
-      add_bits os (Bool.to_int is_final_block) 1
+      add_bits os (if is_final_block then 1 else 0) 1
       ; add_bits os block_type 2
 
     let align_bitstream os =
@@ -3743,7 +3743,7 @@ module Def = struct
         ; seq
 
     let observe_match stats length =
-      let i = num_literal_observation_types + Bool.to_int (length >= 9) in
+      let i = num_literal_observation_types + (if length >= 9 then 1 else 0) in
       stats.new_observations.(i) <- succ stats.new_observations.(i)
       ; stats.num_new_observations <- succ stats.num_new_observations
 

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1550,11 +1550,13 @@ module Inf = struct
                 d.bits <- d.bits + 8))
     [@@inline]
 
-    let rec fill_bits d n =
+    (* clecat: Removed the rec flag on fill_bits, as it was never called with
+       d greater than 16. However, we should make sure that it is never done in
+       the future. *)
+    let fill_bits d n =
       if d.bits < n
       then
-        ( _fill_bits d
-        ; fill_bits d n)
+        _fill_bits d
 
     let pop_bits d n =
       let v = d.hold land (1 lsl n - 1) in
@@ -1568,14 +1570,13 @@ module Inf = struct
     exception Invalid_distance_code
 
     let inflate lit dist d =
-      let rec fill_bits d lit n =
+      let fill_bits d lit n =
         if d.bits < n && not
           (lit.Lookup.t.(d.hold land lit.Lookup.m) land Lookup.mask == 256
           && lit.Lookup.t.(d.hold land lit.Lookup.m) lsr 15 <= d.bits
           && (i_rem d) < 1)
         then
-          ( _fill_bits d
-          ; fill_bits d lit n)
+          _fill_bits d
       in
       try
         let rec length () =

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1455,7 +1455,6 @@ module Inf = struct
       ; mutable i_len : int
       ; mutable hold : int
       ; mutable bits : int
-      ; mutable last : bool
       ; o : bigstring
       ; mutable o_pos : int
       ; w : WInf.t
@@ -1716,7 +1715,6 @@ module Inf = struct
     let rec decode d =
         fill_bits d 3;
         let last = pop_bits d 1 == 1 in
-        d.last <- last ;
         let block_type = pop_bits d 2 in
         ( match block_type with
         | 0 -> flat d
@@ -1724,7 +1722,7 @@ module Inf = struct
         | 2 -> dynamic d
         | 3 -> err_invalid_kind_of_block ()
         | _ -> assert false) ;
-        if d.last
+        if last
         then
           WInf.tail d.w
         else
@@ -1739,7 +1737,6 @@ module Inf = struct
         ; o_pos= 0
         ; hold= 0
         ; bits= 0
-        ; last= false
         ; l= 0
         ; d= 0
         ; w= WInf.from w }

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -2990,24 +2990,19 @@ module Def = struct
     }
 
     type hc_matchfinder = {
-        hash3_tab: int array
-      ; hash4_tab: int array
-      ; mutable next_hash3: int
+        hash4_tab: int array
       ; mutable next_hash4: int
       ; next_tab: int array
     }
 
-    let hc_matchfinder_hash3_order = 15
     let hc_matchfinder_hash4_order = 16
     let window_size = 1 lsl 15
 
     let hc_matchfinder_init () =
-      let hash3_tab =
-        Array.make (1 lsl hc_matchfinder_hash3_order) (-window_size) in
       let hash4_tab =
         Array.make (1 lsl hc_matchfinder_hash4_order) (-window_size) in
       let next_tab = Array.make window_size 0 in
-      {hash3_tab; next_hash3= 0; hash4_tab; next_hash4= 0; next_tab}
+      {hash4_tab; next_hash4= 0; next_tab}
 
     type sequence = {
         mutable litrunlen_and_length: int
@@ -3692,10 +3687,8 @@ module Def = struct
       ; let cutoff = cur_pos - window_size in
         if lens.max < 5 then os.i_pos - best_matchptr
         else
-          let _cur_node3 = mf.hash3_tab.(mf.next_hash3) in
           let cur_node4 = mf.hash4_tab.(mf.next_hash4) in
-          mf.hash3_tab.(mf.next_hash3) <- cur_pos
-          ; mf.hash4_tab.(mf.next_hash4) <- cur_pos
+          mf.hash4_tab.(mf.next_hash4) <- cur_pos
           ; mf.next_tab.(cur_pos) <- cur_node4
           ; mf.next_hash4 <-
               lz_hash os.i (os.i_pos + 1) hc_matchfinder_hash4_order
@@ -3713,7 +3706,6 @@ module Def = struct
       | remaining ->
         let cur_pos = os.i_pos land (window_size - 1) in
         if cur_pos = 0 && os.i_pos <> 0 then hc_matchfinder_slide_window mf
-        ; mf.hash3_tab.(mf.next_hash3) <- cur_pos
         ; mf.next_tab.(cur_pos) <- mf.hash4_tab.(mf.next_hash4)
         ; mf.hash4_tab.(mf.next_hash4) <- cur_pos
         ; os.i_pos <- os.i_pos + 1

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1740,7 +1740,7 @@ module Inf = struct
         | _ -> assert false)
         ; if last then () else decode d
 
-    let inflate ~src ~dst =
+    let inflate src dst =
       let d =
         {
           i= src
@@ -3878,7 +3878,7 @@ module Def = struct
         max 1 ((len + _min_block_length - 1) / _min_block_length) in
       (5 * max_blocks) + len + 1 + _end_padding
 
-    let deflate ?(level = 4) ~src ~dst =
+    let deflate ?(level = 4) src dst =
       let impl, c = encoder level in
       if bigstring_length dst < _end_padding then 0
       else if bigstring_length src < c.min_size_to_compress then (

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -3636,12 +3636,12 @@ module Def = struct
       else _lz_extend i start_pos match_pos len max_len
 
     let hc_matchfinder_slide_window mf =
-      Array.iteri
-        (fun i v -> mf.hash4_tab.(i) <- v - (window_size land 0xFFFF))
-        mf.hash4_tab
-      ; Array.iteri
-          (fun i v -> mf.next_tab.(i) <- v - (window_size land 0xFFFF))
-          mf.next_tab
+      for i = 0 to Array.length mf.hash4_tab - 1 do
+        mf.hash4_tab.(i) <- mf.hash4_tab.(i) - window_size
+      done
+      ; for i = 0 to Array.length mf.next_tab - 1 do
+          mf.next_tab.(i) <- mf.next_tab.(i) - window_size
+        done
 
     let lz_hash i pos num_bits =
       let v = unsafe_get_uint32 i pos in

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1755,7 +1755,7 @@ module Inf = struct
       try
         decode d
         ; Ok (d.i_pos, d.o_pos)
-      with Malformed e -> Error e
+      with Malformed e -> Error (e : error :> [> error ])
   end
 end
 
@@ -3889,7 +3889,7 @@ module Def = struct
             ; flush_output os)
           else impl c src dst in
         Ok res
-      with Malformed e -> Error e
+      with Malformed e -> Error (e : error :> [> error ])
   end
 end
 

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -1452,11 +1452,12 @@ module Inf = struct
     type decoder =
       { i: bigstring
       ; mutable i_pos : int
-      ; mutable i_len : int
+      ; i_len : int
       ; mutable hold : int
       ; mutable bits : int
       ; o : bigstring
       ; mutable o_pos : int
+      ; o_len : int
       ; w : WInf.t
       }
 
@@ -1526,7 +1527,7 @@ module Inf = struct
         ( if len > i_rem d
           then
             err_unexpected_end_of_input () ;
-          if len > bigstring_length d.o - d.o_pos
+          if len > d.o_len - d.o_pos
           then
             err_unexpected_end_of_output () ;
           WInf.blit d.w d.i d.i_pos d.o d.o_pos len ;
@@ -1601,7 +1602,7 @@ module Inf = struct
         and write l d_ =
           if d_ == 0 then raise_notrace Invalid_distance_code ;
           if d_ > WInf.have d.w then raise_notrace Invalid_distance ;
-          let len = min l (bigstring_length d.o - d.o_pos) in
+          let len = min l (d.o_len - d.o_pos) in
           let off = WInf.mask (d.w.WInf.w - d_) in
           if d_ == 1
           then
@@ -1733,6 +1734,7 @@ module Inf = struct
         ; i_len= bigstring_length src
         ; o= dst
         ; o_pos= 0
+        ; o_len= bigstring_length dst
         ; hold= 0
         ; bits= 0
         ; w= WInf.from w }

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -119,6 +119,32 @@ module Inf : sig
 
   val checksum : decoder -> optint
   (** [checkseum d] is ADLER-32 checksum of consumed inputs. *)
+
+  module Non_streamable : sig
+    (** A non-streamable implementation of the RFC 1951. It considers the input
+      to be whole and is therefore able to save some time *)
+
+    type error =
+       | Unexpected_end_of_input
+       | Invalid_kind_of_block
+       | Invalid_dictionary
+       | Invalid_complement_of_length
+       | Invalid_distance
+       | Invalid_distance_code
+    (** The type for inflation errors. *)
+
+    val pp_error: Format.formatter -> error -> unit
+
+    val inflate : src:bigstring -> dst:bigstring -> w:window -> (int * int, error * (int * int)) result
+    (** [inflate src dst w] inflate the content of src into dst using the window
+      w.
+
+      In case of sucess, it returns the bytes read and the bytes writen in an
+      Ok result.
+
+      In case of failure, it returns the error, the bytes read and the bytes
+      writen in an Error result. *)
+  end
 end
 
 (** {2 Queue.}

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -135,8 +135,7 @@ module Inf : sig
 
     val pp_error : Format.formatter -> error -> unit
 
-    val inflate :
-      src:bigstring -> dst:bigstring -> w:window -> (int * int, error) result
+    val inflate : src:bigstring -> dst:bigstring -> (int * int, error) result
     (** [inflate src dst w] inflate the content of src into dst using the window
       w.
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -370,6 +370,19 @@ module Def : sig
      DEFLATE flow is not necessary aligned on bytes. The client can call
      [bits_rem] {b only} when he reachs [`End] case. Otherwise, we raises an
      [Invalid_argument]. *)
+
+  module Ns : sig
+    type error = Invalid_compression_level | Unexpected_end_of_output
+
+    val pp_error : Format.formatter -> error -> unit
+
+    type encoder
+
+    val encoder : int -> encoder
+    val deflate : encoder -> src:bigstring -> dst:bigstring -> int
+    val get_compression_level : encoder -> int
+    val compress_bound : int -> int
+  end
 end
 
 (** {2:compression LZ77 compression algorithm.}

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -378,6 +378,7 @@ module Def : sig
 
     val pp_error : Format.formatter -> error -> unit
     val compress_bound : int -> int
+
     val deflate : ?level:int -> bigstring -> bigstring -> (int, error) result
     (** [deflate ~level src dst] deflates the content of src into dst.
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -136,7 +136,7 @@ module Inf : sig
 
     val pp_error : Format.formatter -> error -> unit
 
-    val inflate : bigstring -> bigstring -> (int * int, error) result
+    val inflate : bigstring -> bigstring -> (int * int, [> error ]) result
     (** [inflate src dst w] inflate the content of src into dst.
 
       In case of sucess, it returns the bytes read and the bytes writen in an
@@ -375,7 +375,8 @@ module Def : sig
     val pp_error : Format.formatter -> error -> unit
     val compress_bound : int -> int
 
-    val deflate : ?level:int -> bigstring -> bigstring -> (int, error) result
+    val deflate :
+      ?level:int -> bigstring -> bigstring -> (int, [> error ]) result
     (** [deflate ~level src dst] deflates the content of src into dst.
 
       In case of sucess, it returns the bytes writen in an Ok result.

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -375,13 +375,8 @@ module Def : sig
     type error = Invalid_compression_level | Unexpected_end_of_output
 
     val pp_error : Format.formatter -> error -> unit
-
-    type encoder
-
-    val encoder : int -> encoder
-    val deflate : encoder -> src:bigstring -> dst:bigstring -> int
-    val get_compression_level : encoder -> int
     val compress_bound : int -> int
+    val deflate : ?level:int -> src:bigstring -> dst:bigstring -> int
   end
 end
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -120,7 +120,7 @@ module Inf : sig
   val checksum : decoder -> optint
   (** [checkseum d] is ADLER-32 checksum of consumed inputs. *)
 
-  module Non_streamable : sig
+  module Ns : sig
     (** A non-streamable implementation of the RFC 1951. It considers the input
       to be whole and is therefore able to save some time *)
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -136,7 +136,7 @@ module Inf : sig
 
     val pp_error : Format.formatter -> error -> unit
 
-    val inflate : src:bigstring -> dst:bigstring -> (int * int, error) result
+    val inflate : bigstring -> bigstring -> (int * int, error) result
     (** [inflate src dst w] inflate the content of src into dst using the window
       w.
 
@@ -380,7 +380,7 @@ module Def : sig
 
     val pp_error : Format.formatter -> error -> unit
     val compress_bound : int -> int
-    val deflate : ?level:int -> src:bigstring -> dst:bigstring -> int
+    val deflate : ?level:int -> bigstring -> bigstring -> int
   end
 end
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -144,7 +144,11 @@ module Inf : sig
       Ok result.
 
       In case of failure, it returns the error, the bytes read and the bytes
-      writen in an Error result. *)
+      writen in an Error result.
+
+      It seems that there is a bug if the input contains more than the encoded
+      parts, the number of read bytes indicated will be to high by 1.
+      Should be investigated ! *)
   end
 end
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -126,6 +126,7 @@ module Inf : sig
 
     type error =
        | Unexpected_end_of_input
+       | Unexpected_end_of_output
        | Invalid_kind_of_block
        | Invalid_dictionary
        | Invalid_complement_of_length
@@ -135,7 +136,7 @@ module Inf : sig
 
     val pp_error: Format.formatter -> error -> unit
 
-    val inflate : src:bigstring -> dst:bigstring -> w:window -> (int * int, error * (int * int)) result
+    val inflate : src:bigstring -> dst:bigstring -> w:window -> (int * int, error) result
     (** [inflate src dst w] inflate the content of src into dst using the window
       w.
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -125,18 +125,18 @@ module Inf : sig
       to be whole and is therefore able to save some time *)
 
     type error =
-       | Unexpected_end_of_input
-       | Unexpected_end_of_output
-       | Invalid_kind_of_block
-       | Invalid_dictionary
-       | Invalid_complement_of_length
-       | Invalid_distance
-       | Invalid_distance_code
-    (** The type for inflation errors. *)
+      | Unexpected_end_of_input
+      | Unexpected_end_of_output
+      | Invalid_kind_of_block
+      | Invalid_dictionary
+      | Invalid_complement_of_length
+      | Invalid_distance
+      | Invalid_distance_code  (** The type for inflation errors. *)
 
-    val pp_error: Format.formatter -> error -> unit
+    val pp_error : Format.formatter -> error -> unit
 
-    val inflate : src:bigstring -> dst:bigstring -> w:window -> (int * int, error) result
+    val inflate :
+      src:bigstring -> dst:bigstring -> w:window -> (int * int, error) result
     (** [inflate src dst w] inflate the content of src into dst using the window
       w.
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -142,11 +142,7 @@ module Inf : sig
       In case of sucess, it returns the bytes read and the bytes writen in an
       Ok result.
 
-      In case of failure, it returns the error in an Error result.
-
-      It seems that there is a bug if the input contains more than the encoded
-      parts, the number of read bytes indicated will be to high by 1.
-      Should be investigated ! *)
+      In case of failure, it returns the error in an Error result. *)
   end
 end
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -125,13 +125,14 @@ module Inf : sig
       to be whole and is therefore able to save some time *)
 
     type error =
-      | Unexpected_end_of_input
-      | Unexpected_end_of_output
-      | Invalid_kind_of_block
-      | Invalid_dictionary
-      | Invalid_complement_of_length
-      | Invalid_distance
-      | Invalid_distance_code  (** The type for inflation errors. *)
+      [ `Unexpected_end_of_input
+      | `Unexpected_end_of_output
+      | `Invalid_kind_of_block
+      | `Invalid_dictionary
+      | `Invalid_complement_of_length
+      | `Invalid_distance
+      | `Invalid_distance_code ]
+    (** The type for inflation errors. *)
 
     val pp_error : Format.formatter -> error -> unit
 

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -137,14 +137,12 @@ module Inf : sig
     val pp_error : Format.formatter -> error -> unit
 
     val inflate : bigstring -> bigstring -> (int * int, error) result
-    (** [inflate src dst w] inflate the content of src into dst using the window
-      w.
+    (** [inflate src dst w] inflate the content of src into dst.
 
       In case of sucess, it returns the bytes read and the bytes writen in an
       Ok result.
 
-      In case of failure, it returns the error, the bytes read and the bytes
-      writen in an Error result.
+      In case of failure, it returns the error in an Error result.
 
       It seems that there is a bug if the input contains more than the encoded
       parts, the number of read bytes indicated will be to high by 1.
@@ -376,11 +374,16 @@ module Def : sig
      [Invalid_argument]. *)
 
   module Ns : sig
-    type error = Invalid_compression_level | Unexpected_end_of_output
+    type error = [ `Invalid_compression_level | `Unexpected_end_of_output ]
 
     val pp_error : Format.formatter -> error -> unit
     val compress_bound : int -> int
-    val deflate : ?level:int -> bigstring -> bigstring -> int
+    val deflate : ?level:int -> bigstring -> bigstring -> (int, error) result
+    (** [deflate ~level src dst] deflates the content of src into dst.
+
+      In case of sucess, it returns the bytes writen in an Ok result.
+
+      In case of failure, it returns the error in an Error result. *)
   end
 end
 

--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -14,6 +14,7 @@ let bigstring_create l =
 
 let bigstring_empty = Bigarray.Array1.create Bigarray.char Bigarray.c_layout 0
 let bigstring_length x = Bigarray.Array1.dim x [@@inline]
+let bigstring_sub x = Bigarray.Array1.sub x [@@inline]
 
 external unsafe_get_uint8 : bigstring -> int -> int = "%caml_ba_ref_1"
 external unsafe_get_uint16 : bigstring -> int -> int = "%caml_bigstring_get16"
@@ -366,6 +367,39 @@ module Inf = struct
     }
 
   let decode d = d.k d
+
+  module Ns = struct
+    type error = [ `Invalid_header | `Invalid_checksum | De.Inf.Ns.error ]
+
+    let pp_error ppf e =
+      match e with
+      | `Invalid_header -> Format.fprintf ppf "Invalid header"
+      | `Invalid_checksum -> Format.fprintf ppf "Invalid checksum"
+      | #De.Inf.Ns.error as e -> De.Inf.Ns.pp_error ppf e
+
+    let header src =
+      let cmf = unsafe_get_uint16 src 0 in
+      let cm = cmf land 0b1111 in
+      let _cinfo = (cmf lsr 4) land 0b1111 in
+      let flg = cmf lsr 8 in
+      let _fdict = (flg lsr 5) land 0b1 in
+      let _flevel = (flg lsr 6) land 0b11 in
+      (((cmf land 0xff) lsl 8) + (cmf lsr 8)) mod 31 != 0 || cm != _deflated
+
+    let inflate ~src ~dst =
+      if header src then Error `Invalid_header
+      else
+        let sub_src = bigstring_sub src 2 (bigstring_length src - 6) in
+        let res = De.Inf.Ns.inflate ~src:sub_src ~dst in
+        match res with
+        | Ok (i, o) ->
+          let i_adl32 = unsafe_get_uint32_be src (i + 2) in
+          let o_adl32 =
+            Optint.to_int32
+              Checkseum.Adler32.(unsafe_digest_bigstring dst 0 o default) in
+          if i_adl32 <> o_adl32 then Error `Invalid_checksum else Ok (i + 6, o)
+        | Error e -> Error (e : De.Inf.Ns.error :> [> error ])
+  end
 end
 
 module Def = struct
@@ -535,6 +569,27 @@ module Def = struct
     }
 
   let encode e = e.k e
+
+  module Ns = struct
+    let compress_bound len = De.Def.Ns.compress_bound len + 6
+
+    let header dst level =
+      let window_bits = 15 in
+      let header = (_deflated + ((window_bits - 8) lsl 4)) lsl 8 in
+      let header = header lor (level lsl 6) in
+      let header = header + (31 - (header mod 31)) in
+      unsafe_set_uint16_be dst 0 header
+
+    let deflate ?(level = 4) ~src ~dst =
+      header dst level
+      ; let sub_dst = bigstring_sub dst 2 (bigstring_length dst - 2) in
+        let res = De.Def.Ns.deflate ~level ~src ~dst:sub_dst in
+        let adl32 =
+          Checkseum.Adler32.(
+            unsafe_digest_bigstring src 0 (bigstring_length src) default) in
+        unsafe_set_uint32_be sub_dst res (Optint.to_int32 adl32)
+        ; res + 6
+  end
 end
 
 module Higher = struct

--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -574,8 +574,7 @@ module Def = struct
     type error = De.Def.Ns.error
 
     let pp_error ppf e =
-      match e with
-      | #De.Def.Ns.error as e -> De.Def.Ns.pp_error ppf e
+      match e with #De.Def.Ns.error as e -> De.Def.Ns.pp_error ppf e
 
     let compress_bound len = De.Def.Ns.compress_bound len + 6
 
@@ -596,10 +595,11 @@ module Def = struct
         | Ok res ->
           let adl32 =
             Checkseum.Adler32.(
-              unsafe_digest_bigstring src 0 (bigstring_length src) default) in
+              unsafe_digest_bigstring src 0 (bigstring_length src) default)
+          in
           unsafe_set_uint32_be sub_dst res (Optint.to_int32 adl32)
           ; Ok (res + 6)
-          | Error e -> Error (e : De.Def.Ns.error :> [> error ])
+        | Error e -> Error (e : De.Def.Ns.error :> [> error ])
   end
 end
 

--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -576,7 +576,8 @@ module Def = struct
     let header dst level =
       let window_bits = 15 in
       let header = (_deflated + ((window_bits - 8) lsl 4)) lsl 8 in
-      let level = match level with 0 | 1 -> 0 | 2 | 3 | 4 | 5 -> 1 | 6 -> 2 | _ -> 3 in
+      let level =
+        match level with 0 | 1 -> 0 | 2 | 3 | 4 | 5 -> 1 | 6 -> 2 | _ -> 3 in
       let header = header lor (level lsl 6) in
       let header = header + (31 - (header mod 31)) in
       unsafe_set_uint16_be dst 0 header

--- a/lib/zl.mli
+++ b/lib/zl.mli
@@ -110,6 +110,26 @@ module Inf : sig
   val flush : decoder -> decoder
   (** [flush d] is a decoder where internal output buffer [o] is {b completely}
      free to store bytes. *)
+
+  module Ns : sig
+    (** A non-streamable implementation of the RFC 1950. It considers the input
+    to be whole and is therefore able to save some time *)
+
+    type error = [ `Invalid_header | `Invalid_checksum | De.Inf.Ns.error ]
+
+    val pp_error : Format.formatter -> error -> unit
+
+    val inflate :
+      src:bigstring -> dst:bigstring -> (int * int, [> error ]) result
+    (** [inflate src dst w] inflate the content of src into dst using the window
+    w.
+
+    In case of sucess, it returns the bytes read and the bytes writen in an
+    Ok result.
+
+    In case of failure, it returns the error, the bytes read and the bytes
+    writen in an Error result. *)
+  end
 end
 
 (** {2:encode ZLIB Encoder.}
@@ -211,6 +231,11 @@ module Def : sig
      did nothing. Depending on what you do, a loop can infinitely call [encode]
      without any updates until the given output still has less than 2 bytes.
    *)
+
+  module Ns : sig
+    val compress_bound : int -> int
+    val deflate : ?level:int -> src:bigstring -> dst:bigstring -> int
+  end
 end
 
 module Higher : sig

--- a/lib/zl.mli
+++ b/lib/zl.mli
@@ -120,14 +120,6 @@ module Inf : sig
     val pp_error : Format.formatter -> error -> unit
 
     val inflate : bigstring -> bigstring -> (int * int, [> error ]) result
-    (** [inflate src dst w] inflate the content of src into dst using the window
-    w.
-
-    In case of sucess, it returns the bytes read and the bytes writen in an
-    Ok result.
-
-    In case of failure, it returns the error, the bytes read and the bytes
-    writen in an Error result. *)
   end
 end
 
@@ -232,8 +224,13 @@ module Def : sig
    *)
 
   module Ns : sig
+    type error = De.Def.Ns.error
+
+    val pp_error : Format.formatter -> error -> unit
+
     val compress_bound : int -> int
-    val deflate : ?level:int -> bigstring -> bigstring -> int
+
+    val deflate : ?level:int -> bigstring -> bigstring -> (int, [> error]) result
   end
 end
 

--- a/lib/zl.mli
+++ b/lib/zl.mli
@@ -119,8 +119,7 @@ module Inf : sig
 
     val pp_error : Format.formatter -> error -> unit
 
-    val inflate :
-      bigstring -> bigstring -> (int * int, [> error ]) result
+    val inflate : bigstring -> bigstring -> (int * int, [> error ]) result
     (** [inflate src dst w] inflate the content of src into dst using the window
     w.
 

--- a/lib/zl.mli
+++ b/lib/zl.mli
@@ -120,7 +120,7 @@ module Inf : sig
     val pp_error : Format.formatter -> error -> unit
 
     val inflate :
-      src:bigstring -> dst:bigstring -> (int * int, [> error ]) result
+      bigstring -> bigstring -> (int * int, [> error ]) result
     (** [inflate src dst w] inflate the content of src into dst using the window
     w.
 
@@ -234,7 +234,7 @@ module Def : sig
 
   module Ns : sig
     val compress_bound : int -> int
-    val deflate : ?level:int -> src:bigstring -> dst:bigstring -> int
+    val deflate : ?level:int -> bigstring -> bigstring -> int
   end
 end
 

--- a/lib/zl.mli
+++ b/lib/zl.mli
@@ -118,7 +118,6 @@ module Inf : sig
     type error = [ `Invalid_header | `Invalid_checksum | De.Inf.Ns.error ]
 
     val pp_error : Format.formatter -> error -> unit
-
     val inflate : bigstring -> bigstring -> (int * int, [> error ]) result
   end
 end
@@ -227,10 +226,10 @@ module Def : sig
     type error = De.Def.Ns.error
 
     val pp_error : Format.formatter -> error -> unit
-
     val compress_bound : int -> int
 
-    val deflate : ?level:int -> bigstring -> bigstring -> (int, [> error]) result
+    val deflate :
+      ?level:int -> bigstring -> bigstring -> (int, [> error ]) result
   end
 end
 

--- a/lib/zl.mli
+++ b/lib/zl.mli
@@ -113,12 +113,20 @@ module Inf : sig
 
   module Ns : sig
     (** A non-streamable implementation of the RFC 1950. It considers the input
-    to be whole and is therefore able to save some time *)
+        to be whole and is therefore able to save some time *)
 
     type error = [ `Invalid_header | `Invalid_checksum | De.Inf.Ns.error ]
+    (** The type for inflation errors. *)
 
     val pp_error : Format.formatter -> error -> unit
+    (** Pretty-printer of {!error}. *)
+
     val inflate : bigstring -> bigstring -> (int * int, [> error ]) result
+    (** [inflate src dst] inflates the content of [src] into [dst].
+
+        In case of success, it returns the bytes read and bytes writen in an
+       [Ok] result. In case of failure, it returns the error in a [Error]
+       result. *)
   end
 end
 
@@ -224,12 +232,33 @@ module Def : sig
 
   module Ns : sig
     type error = De.Def.Ns.error
+    (** The type for deflation errors. *)
 
     val pp_error : Format.formatter -> error -> unit
+    (** Pretty-printer for {!error}. *)
+
     val compress_bound : int -> int
+    (** [compress_bound len] returns a {i clue} about how many bytes we need
+       to store the result of the deflation of [len] bytes. It's a
+       pessimistic calculation. *)
 
     val deflate :
       ?level:int -> bigstring -> bigstring -> (int, [> error ]) result
+    (** [deflate ~level src dst] deflates the content of [src] into [dst].
+
+        In case of success, it returns the bytes writen in an [Ok] result. In case
+       of failure, it returns the error in an [Error] result. {!compress_bound}
+       can be used to {i determine} how many bytes the user needs to allocate
+       as the destination buffer when he wants to compress [N] bytes.
+
+        Here is an example of how to compress any inputs:
+        {[
+          val input : bigstring
+
+          let len = Zl.Def.Ns.compress_bound (De.bigstring_length input) in
+          let dst = De.bigstring_create len in
+          Zl.Def.Ns.deflate ~level:4 input dst
+        ]} *)
   end
 end
 

--- a/test/dune
+++ b/test/dune
@@ -23,6 +23,15 @@
  (alias runtest)
  (package decompress)
  (deps
+  (:test test_deflate.exe)
+  (source_tree corpus))
+ (action
+  (run %{test} --color=always)))
+
+(rule
+ (alias runtest)
+ (package decompress)
+ (deps
   (:test test.exe)
   (source_tree corpus))
  (action

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (modules test)
+ (modules test test_ns)
  (libraries
   fmt
   base64

--- a/test/dune
+++ b/test/dune
@@ -23,15 +23,6 @@
  (alias runtest)
  (package decompress)
  (deps
-  (:test test_deflate.exe)
-  (source_tree corpus))
- (action
-  (run %{test} --color=always)))
-
-(rule
- (alias runtest)
- (package decompress)
- (deps
   (:test test.exe)
   (source_tree corpus))
  (action

--- a/test/test.ml
+++ b/test/test.ml
@@ -2019,88 +2019,86 @@ let small_queue () =
 
 let () =
   Alcotest.run "z"
-    ([
-       ( "invalids"
-       , [
-           invalid_complement_of_length (); invalid_kind_of_block ()
-         ; invalid_code_lengths (); invalid_bit_length_repeat ()
-         ; invalid_codes (); invalid_lengths (); invalid_distances ()
-         ; too_many_length_or_distance_symbols (); invalid_distance_code ()
-         ; invalid_distance_too_far_back (); invalid_access ()
-         ] )
-     ; ( "valids"
-       , [
-           fixed (); stored (); length_extra (); long_distance_and_extra ()
-         ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
-         ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
-         ; flat_block (); flat (); max_flat (); fixed_and_flat ()
-         ; flat_and_fixed ()
-         ] )
-     ; ( "fuzz"
-       , [
-           fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
-         ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 ()
-         ; fuzz13 (); fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
-         ] ); "huffman", [tree_0 (); tree_rfc5322_corpus ()]
-     ; ( "lz77"
-       , [
-           lz77_0 (); lz77_1 (); lz77_2 (); lz77_3 (); lz77_4 ()
-         ; lz77_corpus_rfc5322 ()
-         ] )
-     ; ( "calgary"
-       , [
-           test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
-         ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
-         ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
-         ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
-         ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
-         ] )
-     ; ( "zlib"
-       , [
-           test_empty_with_zlib (); test_empty_with_zlib_and_small_output ()
-         ; test_empty_with_zlib_byte_per_byte (); test_corpus_with_zlib "bib"
-         ; test_corpus_with_zlib "book1"; test_corpus_with_zlib "book2"
-         ; test_corpus_with_zlib "geo"; test_corpus_with_zlib "news"
-         ; test_corpus_with_zlib "obj1"; test_corpus_with_zlib "obj2"
-         ; test_corpus_with_zlib "paper1"; test_corpus_with_zlib "paper2"
-         ; test_corpus_with_zlib "pic"; test_corpus_with_zlib "progc"
-         ; test_corpus_with_zlib "progl"; test_corpus_with_zlib "progp"
-         ; test_corpus_with_zlib "trans"; test_multiple_flush_zlib ()
-         ] )
-     ; ( "gzip"
-       , [
-           test_empty_gzip (); test_empty_gzip_with_name (); test_foo_gzip ()
-         ; test_multiple_flush_gzip (); test_generate_empty_gzip ()
-         ; test_generate_empty_gzip_with_name (); test_generate_foo_gzip ()
-         ; test_corpus_with_gzip "bib"; test_corpus_with_gzip "book1"
-         ; test_corpus_with_gzip "book2"; test_corpus_with_gzip "geo"
-         ; test_corpus_with_gzip "news"; test_corpus_with_gzip "obj1"
-         ; test_corpus_with_gzip "obj2"; test_corpus_with_gzip "paper1"
-         ; test_corpus_with_gzip "paper2"; test_corpus_with_gzip "pic"
-         ; test_corpus_with_gzip "progc"; test_corpus_with_gzip "progl"
-         ; test_corpus_with_gzip "progp"; test_corpus_with_gzip "trans"
-         ; test_with_camlzip (); test_gzip_hcrc (); test_invalid_hcrc ()
-         ; test_gzip_extra ()
-         ] )
-     ; ( "gzip with os"
-       , [
-           test_gzip_os Gz.FAT; test_gzip_os Gz.Amiga; test_gzip_os Gz.VMS
-         ; test_gzip_os Gz.Unix; test_gzip_os Gz.VM; test_gzip_os Gz.Atari
-         ; test_gzip_os Gz.HPFS; test_gzip_os Gz.Macintosh; test_gzip_os Gz.Z
-         ; test_gzip_os Gz.CPM; test_gzip_os Gz.TOPS20; test_gzip_os Gz.NTFS
-         ; test_gzip_os Gz.QDOS; test_gzip_os Gz.Acorn; test_gzip_os Gz.Unknown
-         ] )
-     ; ( "lzo"
-       , [
-           test_lzo_0 (); test_lzo_1 (); test_corpus_with_lzo "obj1"
-         ; test_corpus_with_lzo "obj2"; test_corpus_with_lzo "geo"
-         ; test_corpus_with_lzo "news"; test_corpus_with_lzo "pic"
-         ; test_corpus_with_lzo "progc"; test_corpus_with_lzo "progl"
-         ; test_corpus_with_lzo "progp"; test_corpus_with_lzo "trans"
-         ; test_corpus_with_lzo "paper1"; test_corpus_with_lzo "paper2"
-         ; test_corpus_with_lzo "book1"; test_corpus_with_lzo "book2"
-         ] ); "hang", [hang0 ()]; "git", [git_object ()]
-     ; ( "higher"
-       , [higher_zlib0 (); higher_zlib1 (); higher_zlib2 (); higher_zlib3 ()] )
-     ]
+    ([ (* ( "invalids"
+            , [
+                invalid_complement_of_length (); invalid_kind_of_block ()
+              ; invalid_code_lengths (); invalid_bit_length_repeat ()
+              ; invalid_codes (); invalid_lengths (); invalid_distances ()
+              ; too_many_length_or_distance_symbols (); invalid_distance_code ()
+              ; invalid_distance_too_far_back (); invalid_access ()
+              ] )
+          ; ( "valids"
+            , [
+                fixed (); stored (); length_extra (); long_distance_and_extra ()
+              ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
+              ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
+              ; flat_block (); flat (); max_flat (); fixed_and_flat ()
+              ; flat_and_fixed ()
+              ] )
+          ; ( "fuzz"
+            , [
+                fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
+              ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 ()
+              ; fuzz13 (); fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
+              ] ); "huffman", [tree_0 (); tree_rfc5322_corpus ()]
+          ; ( "lz77"
+            , [
+                lz77_0 (); lz77_1 (); lz77_2 (); lz77_3 (); lz77_4 ()
+              ; lz77_corpus_rfc5322 ()
+              ] )
+          ; ( "calgary"
+            , [
+                test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
+              ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
+              ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
+              ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
+              ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
+              ] )
+          ; ( "zlib"
+            , [
+                test_empty_with_zlib (); test_empty_with_zlib_and_small_output ()
+              ; test_empty_with_zlib_byte_per_byte (); test_corpus_with_zlib "bib"
+              ; test_corpus_with_zlib "book1"; test_corpus_with_zlib "book2"
+              ; test_corpus_with_zlib "geo"; test_corpus_with_zlib "news"
+              ; test_corpus_with_zlib "obj1"; test_corpus_with_zlib "obj2"
+              ; test_corpus_with_zlib "paper1"; test_corpus_with_zlib "paper2"
+              ; test_corpus_with_zlib "pic"; test_corpus_with_zlib "progc"
+              ; test_corpus_with_zlib "progl"; test_corpus_with_zlib "progp"
+              ; test_corpus_with_zlib "trans"; test_multiple_flush_zlib ()
+              ] )
+          ; ( "gzip"
+            , [
+                test_empty_gzip (); test_empty_gzip_with_name (); test_foo_gzip ()
+              ; test_multiple_flush_gzip (); test_generate_empty_gzip ()
+              ; test_generate_empty_gzip_with_name (); test_generate_foo_gzip ()
+              ; test_corpus_with_gzip "bib"; test_corpus_with_gzip "book1"
+              ; test_corpus_with_gzip "book2"; test_corpus_with_gzip "geo"
+              ; test_corpus_with_gzip "news"; test_corpus_with_gzip "obj1"
+              ; test_corpus_with_gzip "obj2"; test_corpus_with_gzip "paper1"
+              ; test_corpus_with_gzip "paper2"; test_corpus_with_gzip "pic"
+              ; test_corpus_with_gzip "progc"; test_corpus_with_gzip "progl"
+              ; test_corpus_with_gzip "progp"; test_corpus_with_gzip "trans"
+              ; test_with_camlzip (); test_gzip_hcrc (); test_invalid_hcrc ()
+              ; test_gzip_extra ()
+              ] )
+          ; ( "gzip with os"
+            , [
+                test_gzip_os Gz.FAT; test_gzip_os Gz.Amiga; test_gzip_os Gz.VMS
+              ; test_gzip_os Gz.Unix; test_gzip_os Gz.VM; test_gzip_os Gz.Atari
+              ; test_gzip_os Gz.HPFS; test_gzip_os Gz.Macintosh; test_gzip_os Gz.Z
+              ; test_gzip_os Gz.CPM; test_gzip_os Gz.TOPS20; test_gzip_os Gz.NTFS
+              ; test_gzip_os Gz.QDOS; test_gzip_os Gz.Acorn; test_gzip_os Gz.Unknown
+              ] )
+          ; ( "lzo"
+            , [
+                test_lzo_0 (); test_lzo_1 (); test_corpus_with_lzo "obj1"
+              ; test_corpus_with_lzo "obj2"; test_corpus_with_lzo "geo"
+              ; test_corpus_with_lzo "news"; test_corpus_with_lzo "pic"
+              ; test_corpus_with_lzo "progc"; test_corpus_with_lzo "progl"
+              ; test_corpus_with_lzo "progp"; test_corpus_with_lzo "trans"
+              ; test_corpus_with_lzo "paper1"; test_corpus_with_lzo "paper2"
+              ; test_corpus_with_lzo "book1"; test_corpus_with_lzo "book2"
+              ] ); "hang", [hang0 ()]; "git", [git_object ()]
+          ; ( "higher"
+            , [higher_zlib0 (); higher_zlib1 (); higher_zlib2 (); higher_zlib3 ()] ) *) ]
     @ Test_ns.tests)

--- a/test/test.ml
+++ b/test/test.ml
@@ -2019,7 +2019,7 @@ let small_queue () =
 
 let () =
   Alcotest.run "z"
-    ([ (* ( "invalids"
+    ([ ( "invalids"
             , [
                 invalid_complement_of_length (); invalid_kind_of_block ()
               ; invalid_code_lengths (); invalid_bit_length_repeat ()
@@ -2100,5 +2100,5 @@ let () =
               ; test_corpus_with_lzo "book1"; test_corpus_with_lzo "book2"
               ] ); "hang", [hang0 ()]; "git", [git_object ()]
           ; ( "higher"
-            , [higher_zlib0 (); higher_zlib1 (); higher_zlib2 (); higher_zlib3 ()] ) *) ]
+            , [higher_zlib0 (); higher_zlib1 (); higher_zlib2 (); higher_zlib3 ()] ) ]
     @ Test_ns.tests)

--- a/test/test.ml
+++ b/test/test.ml
@@ -2045,7 +2045,7 @@ let () =
      ; ( "lz77"
        , [
            lz77_0 (); lz77_1 (); lz77_2 (); lz77_3 (); lz77_4 ()
-         ; lz77_corpus_rfc5322 ()
+         ; lz77_corpus_rfc5322 (); small_queue ()
          ] )
      ; ( "calgary"
        , [

--- a/test/test.ml
+++ b/test/test.ml
@@ -2019,86 +2019,88 @@ let small_queue () =
 
 let () =
   Alcotest.run "z"
-    ([ ( "invalids"
-            , [
-                invalid_complement_of_length (); invalid_kind_of_block ()
-              ; invalid_code_lengths (); invalid_bit_length_repeat ()
-              ; invalid_codes (); invalid_lengths (); invalid_distances ()
-              ; too_many_length_or_distance_symbols (); invalid_distance_code ()
-              ; invalid_distance_too_far_back (); invalid_access ()
-              ] )
-          ; ( "valids"
-            , [
-                fixed (); stored (); length_extra (); long_distance_and_extra ()
-              ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
-              ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
-              ; flat_block (); flat (); max_flat (); fixed_and_flat ()
-              ; flat_and_fixed ()
-              ] )
-          ; ( "fuzz"
-            , [
-                fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
-              ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 ()
-              ; fuzz13 (); fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
-              ] ); "huffman", [tree_0 (); tree_rfc5322_corpus ()]
-          ; ( "lz77"
-            , [
-                lz77_0 (); lz77_1 (); lz77_2 (); lz77_3 (); lz77_4 ()
-              ; lz77_corpus_rfc5322 ()
-              ] )
-          ; ( "calgary"
-            , [
-                test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
-              ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
-              ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
-              ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
-              ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
-              ] )
-          ; ( "zlib"
-            , [
-                test_empty_with_zlib (); test_empty_with_zlib_and_small_output ()
-              ; test_empty_with_zlib_byte_per_byte (); test_corpus_with_zlib "bib"
-              ; test_corpus_with_zlib "book1"; test_corpus_with_zlib "book2"
-              ; test_corpus_with_zlib "geo"; test_corpus_with_zlib "news"
-              ; test_corpus_with_zlib "obj1"; test_corpus_with_zlib "obj2"
-              ; test_corpus_with_zlib "paper1"; test_corpus_with_zlib "paper2"
-              ; test_corpus_with_zlib "pic"; test_corpus_with_zlib "progc"
-              ; test_corpus_with_zlib "progl"; test_corpus_with_zlib "progp"
-              ; test_corpus_with_zlib "trans"; test_multiple_flush_zlib ()
-              ] )
-          ; ( "gzip"
-            , [
-                test_empty_gzip (); test_empty_gzip_with_name (); test_foo_gzip ()
-              ; test_multiple_flush_gzip (); test_generate_empty_gzip ()
-              ; test_generate_empty_gzip_with_name (); test_generate_foo_gzip ()
-              ; test_corpus_with_gzip "bib"; test_corpus_with_gzip "book1"
-              ; test_corpus_with_gzip "book2"; test_corpus_with_gzip "geo"
-              ; test_corpus_with_gzip "news"; test_corpus_with_gzip "obj1"
-              ; test_corpus_with_gzip "obj2"; test_corpus_with_gzip "paper1"
-              ; test_corpus_with_gzip "paper2"; test_corpus_with_gzip "pic"
-              ; test_corpus_with_gzip "progc"; test_corpus_with_gzip "progl"
-              ; test_corpus_with_gzip "progp"; test_corpus_with_gzip "trans"
-              ; test_with_camlzip (); test_gzip_hcrc (); test_invalid_hcrc ()
-              ; test_gzip_extra ()
-              ] )
-          ; ( "gzip with os"
-            , [
-                test_gzip_os Gz.FAT; test_gzip_os Gz.Amiga; test_gzip_os Gz.VMS
-              ; test_gzip_os Gz.Unix; test_gzip_os Gz.VM; test_gzip_os Gz.Atari
-              ; test_gzip_os Gz.HPFS; test_gzip_os Gz.Macintosh; test_gzip_os Gz.Z
-              ; test_gzip_os Gz.CPM; test_gzip_os Gz.TOPS20; test_gzip_os Gz.NTFS
-              ; test_gzip_os Gz.QDOS; test_gzip_os Gz.Acorn; test_gzip_os Gz.Unknown
-              ] )
-          ; ( "lzo"
-            , [
-                test_lzo_0 (); test_lzo_1 (); test_corpus_with_lzo "obj1"
-              ; test_corpus_with_lzo "obj2"; test_corpus_with_lzo "geo"
-              ; test_corpus_with_lzo "news"; test_corpus_with_lzo "pic"
-              ; test_corpus_with_lzo "progc"; test_corpus_with_lzo "progl"
-              ; test_corpus_with_lzo "progp"; test_corpus_with_lzo "trans"
-              ; test_corpus_with_lzo "paper1"; test_corpus_with_lzo "paper2"
-              ; test_corpus_with_lzo "book1"; test_corpus_with_lzo "book2"
-              ] ); "hang", [hang0 ()]; "git", [git_object ()]
-          ; ( "higher"
-            , [higher_zlib0 (); higher_zlib1 (); higher_zlib2 (); higher_zlib3 ()] ) ]
+    ([
+       ( "invalids"
+       , [
+           invalid_complement_of_length (); invalid_kind_of_block ()
+         ; invalid_code_lengths (); invalid_bit_length_repeat ()
+         ; invalid_codes (); invalid_lengths (); invalid_distances ()
+         ; too_many_length_or_distance_symbols (); invalid_distance_code ()
+         ; invalid_distance_too_far_back (); invalid_access ()
+         ] )
+     ; ( "valids"
+       , [
+           fixed (); stored (); length_extra (); long_distance_and_extra ()
+         ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
+         ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
+         ; flat_block (); flat (); max_flat (); fixed_and_flat ()
+         ; flat_and_fixed ()
+         ] )
+     ; ( "fuzz"
+       , [
+           fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
+         ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 ()
+         ; fuzz13 (); fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
+         ] ); "huffman", [tree_0 (); tree_rfc5322_corpus ()]
+     ; ( "lz77"
+       , [
+           lz77_0 (); lz77_1 (); lz77_2 (); lz77_3 (); lz77_4 ()
+         ; lz77_corpus_rfc5322 ()
+         ] )
+     ; ( "calgary"
+       , [
+           test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
+         ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
+         ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
+         ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
+         ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
+         ] )
+     ; ( "zlib"
+       , [
+           test_empty_with_zlib (); test_empty_with_zlib_and_small_output ()
+         ; test_empty_with_zlib_byte_per_byte (); test_corpus_with_zlib "bib"
+         ; test_corpus_with_zlib "book1"; test_corpus_with_zlib "book2"
+         ; test_corpus_with_zlib "geo"; test_corpus_with_zlib "news"
+         ; test_corpus_with_zlib "obj1"; test_corpus_with_zlib "obj2"
+         ; test_corpus_with_zlib "paper1"; test_corpus_with_zlib "paper2"
+         ; test_corpus_with_zlib "pic"; test_corpus_with_zlib "progc"
+         ; test_corpus_with_zlib "progl"; test_corpus_with_zlib "progp"
+         ; test_corpus_with_zlib "trans"; test_multiple_flush_zlib ()
+         ] )
+     ; ( "gzip"
+       , [
+           test_empty_gzip (); test_empty_gzip_with_name (); test_foo_gzip ()
+         ; test_multiple_flush_gzip (); test_generate_empty_gzip ()
+         ; test_generate_empty_gzip_with_name (); test_generate_foo_gzip ()
+         ; test_corpus_with_gzip "bib"; test_corpus_with_gzip "book1"
+         ; test_corpus_with_gzip "book2"; test_corpus_with_gzip "geo"
+         ; test_corpus_with_gzip "news"; test_corpus_with_gzip "obj1"
+         ; test_corpus_with_gzip "obj2"; test_corpus_with_gzip "paper1"
+         ; test_corpus_with_gzip "paper2"; test_corpus_with_gzip "pic"
+         ; test_corpus_with_gzip "progc"; test_corpus_with_gzip "progl"
+         ; test_corpus_with_gzip "progp"; test_corpus_with_gzip "trans"
+         ; test_with_camlzip (); test_gzip_hcrc (); test_invalid_hcrc ()
+         ; test_gzip_extra ()
+         ] )
+     ; ( "gzip with os"
+       , [
+           test_gzip_os Gz.FAT; test_gzip_os Gz.Amiga; test_gzip_os Gz.VMS
+         ; test_gzip_os Gz.Unix; test_gzip_os Gz.VM; test_gzip_os Gz.Atari
+         ; test_gzip_os Gz.HPFS; test_gzip_os Gz.Macintosh; test_gzip_os Gz.Z
+         ; test_gzip_os Gz.CPM; test_gzip_os Gz.TOPS20; test_gzip_os Gz.NTFS
+         ; test_gzip_os Gz.QDOS; test_gzip_os Gz.Acorn; test_gzip_os Gz.Unknown
+         ] )
+     ; ( "lzo"
+       , [
+           test_lzo_0 (); test_lzo_1 (); test_corpus_with_lzo "obj1"
+         ; test_corpus_with_lzo "obj2"; test_corpus_with_lzo "geo"
+         ; test_corpus_with_lzo "news"; test_corpus_with_lzo "pic"
+         ; test_corpus_with_lzo "progc"; test_corpus_with_lzo "progl"
+         ; test_corpus_with_lzo "progp"; test_corpus_with_lzo "trans"
+         ; test_corpus_with_lzo "paper1"; test_corpus_with_lzo "paper2"
+         ; test_corpus_with_lzo "book1"; test_corpus_with_lzo "book2"
+         ] ); "hang", [hang0 ()]; "git", [git_object ()]
+     ; ( "higher"
+       , [higher_zlib0 (); higher_zlib1 (); higher_zlib2 (); higher_zlib3 ()] )
+     ]
     @ Test_ns.tests)

--- a/test/test.ml
+++ b/test/test.ml
@@ -2019,87 +2019,88 @@ let small_queue () =
 
 let () =
   Alcotest.run "z"
-    [
-      ( "invalids"
-      , [
-          invalid_complement_of_length (); invalid_kind_of_block ()
-        ; invalid_code_lengths (); invalid_bit_length_repeat ()
-        ; invalid_codes (); invalid_lengths (); invalid_distances ()
-        ; too_many_length_or_distance_symbols (); invalid_distance_code ()
-        ; invalid_distance_too_far_back (); invalid_access ()
-        ] )
-    ; ( "valids"
-      , [
-          fixed (); stored (); length_extra (); long_distance_and_extra ()
-        ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
-        ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
-        ; flat_block (); flat (); max_flat (); fixed_and_flat ()
-        ; flat_and_fixed ()
-        ] )
-    ; ( "fuzz"
-      , [
-          fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
-        ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 ()
-        ; fuzz13 (); fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
-        ] ); "huffman", [tree_0 (); tree_rfc5322_corpus ()]
-    ; ( "lz77"
-      , [
-          lz77_0 (); lz77_1 (); lz77_2 (); lz77_3 (); lz77_4 ()
-        ; lz77_corpus_rfc5322 (); small_queue ()
-        ] )
-    ; ( "calgary"
-      , [
-          test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
-        ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
-        ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
-        ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
-        ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
-        ] )
-    ; ( "zlib"
-      , [
-          test_empty_with_zlib (); test_empty_with_zlib_and_small_output ()
-        ; test_empty_with_zlib_byte_per_byte (); test_corpus_with_zlib "bib"
-        ; test_corpus_with_zlib "book1"; test_corpus_with_zlib "book2"
-        ; test_corpus_with_zlib "geo"; test_corpus_with_zlib "news"
-        ; test_corpus_with_zlib "obj1"; test_corpus_with_zlib "obj2"
-        ; test_corpus_with_zlib "paper1"; test_corpus_with_zlib "paper2"
-        ; test_corpus_with_zlib "pic"; test_corpus_with_zlib "progc"
-        ; test_corpus_with_zlib "progl"; test_corpus_with_zlib "progp"
-        ; test_corpus_with_zlib "trans"; test_multiple_flush_zlib ()
-        ] )
-    ; ( "gzip"
-      , [
-          test_empty_gzip (); test_empty_gzip_with_name (); test_foo_gzip ()
-        ; test_multiple_flush_gzip (); test_generate_empty_gzip ()
-        ; test_generate_empty_gzip_with_name (); test_generate_foo_gzip ()
-        ; test_corpus_with_gzip "bib"; test_corpus_with_gzip "book1"
-        ; test_corpus_with_gzip "book2"; test_corpus_with_gzip "geo"
-        ; test_corpus_with_gzip "news"; test_corpus_with_gzip "obj1"
-        ; test_corpus_with_gzip "obj2"; test_corpus_with_gzip "paper1"
-        ; test_corpus_with_gzip "paper2"; test_corpus_with_gzip "pic"
-        ; test_corpus_with_gzip "progc"; test_corpus_with_gzip "progl"
-        ; test_corpus_with_gzip "progp"; test_corpus_with_gzip "trans"
-        ; test_with_camlzip (); test_gzip_hcrc (); test_invalid_hcrc ()
-        ; test_gzip_extra (); test_gzip_huge ()
-        ] )
-    ; ( "gzip with os"
-      , [
-          test_gzip_os Gz.FAT; test_gzip_os Gz.Amiga; test_gzip_os Gz.VMS
-        ; test_gzip_os Gz.Unix; test_gzip_os Gz.VM; test_gzip_os Gz.Atari
-        ; test_gzip_os Gz.HPFS; test_gzip_os Gz.Macintosh; test_gzip_os Gz.Z
-        ; test_gzip_os Gz.CPM; test_gzip_os Gz.TOPS20; test_gzip_os Gz.NTFS
-        ; test_gzip_os Gz.QDOS; test_gzip_os Gz.Acorn; test_gzip_os Gz.Unknown
-        ] )
-    ; ( "lzo"
-      , [
-          test_lzo_0 (); test_lzo_1 (); test_corpus_with_lzo "obj1"
-        ; test_corpus_with_lzo "obj2"; test_corpus_with_lzo "geo"
-        ; test_corpus_with_lzo "news"; test_corpus_with_lzo "pic"
-        ; test_corpus_with_lzo "progc"; test_corpus_with_lzo "progl"
-        ; test_corpus_with_lzo "progp"; test_corpus_with_lzo "trans"
-        ; test_corpus_with_lzo "paper1"; test_corpus_with_lzo "paper2"
-        ; test_corpus_with_lzo "book1"; test_corpus_with_lzo "book2"
-        ] ); "hang", [hang0 ()]; "git", [git_object ()]
-    ; ( "higher"
-      , [higher_zlib0 (); higher_zlib1 (); higher_zlib2 (); higher_zlib3 ()] )
-    ]
+    ([
+       ( "invalids"
+       , [
+           invalid_complement_of_length (); invalid_kind_of_block ()
+         ; invalid_code_lengths (); invalid_bit_length_repeat ()
+         ; invalid_codes (); invalid_lengths (); invalid_distances ()
+         ; too_many_length_or_distance_symbols (); invalid_distance_code ()
+         ; invalid_distance_too_far_back (); invalid_access ()
+         ] )
+     ; ( "valids"
+       , [
+           fixed (); stored (); length_extra (); long_distance_and_extra ()
+         ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
+         ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
+         ; flat_block (); flat (); max_flat (); fixed_and_flat ()
+         ; flat_and_fixed ()
+         ] )
+     ; ( "fuzz"
+       , [
+           fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
+         ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 ()
+         ; fuzz13 (); fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
+         ] ); "huffman", [tree_0 (); tree_rfc5322_corpus ()]
+     ; ( "lz77"
+       , [
+           lz77_0 (); lz77_1 (); lz77_2 (); lz77_3 (); lz77_4 ()
+         ; lz77_corpus_rfc5322 ()
+         ] )
+     ; ( "calgary"
+       , [
+           test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
+         ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
+         ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
+         ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
+         ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
+         ] )
+     ; ( "zlib"
+       , [
+           test_empty_with_zlib (); test_empty_with_zlib_and_small_output ()
+         ; test_empty_with_zlib_byte_per_byte (); test_corpus_with_zlib "bib"
+         ; test_corpus_with_zlib "book1"; test_corpus_with_zlib "book2"
+         ; test_corpus_with_zlib "geo"; test_corpus_with_zlib "news"
+         ; test_corpus_with_zlib "obj1"; test_corpus_with_zlib "obj2"
+         ; test_corpus_with_zlib "paper1"; test_corpus_with_zlib "paper2"
+         ; test_corpus_with_zlib "pic"; test_corpus_with_zlib "progc"
+         ; test_corpus_with_zlib "progl"; test_corpus_with_zlib "progp"
+         ; test_corpus_with_zlib "trans"; test_multiple_flush_zlib ()
+         ] )
+     ; ( "gzip"
+       , [
+           test_empty_gzip (); test_empty_gzip_with_name (); test_foo_gzip ()
+         ; test_multiple_flush_gzip (); test_generate_empty_gzip ()
+         ; test_generate_empty_gzip_with_name (); test_generate_foo_gzip ()
+         ; test_corpus_with_gzip "bib"; test_corpus_with_gzip "book1"
+         ; test_corpus_with_gzip "book2"; test_corpus_with_gzip "geo"
+         ; test_corpus_with_gzip "news"; test_corpus_with_gzip "obj1"
+         ; test_corpus_with_gzip "obj2"; test_corpus_with_gzip "paper1"
+         ; test_corpus_with_gzip "paper2"; test_corpus_with_gzip "pic"
+         ; test_corpus_with_gzip "progc"; test_corpus_with_gzip "progl"
+         ; test_corpus_with_gzip "progp"; test_corpus_with_gzip "trans"
+         ; test_with_camlzip (); test_gzip_hcrc (); test_invalid_hcrc ()
+         ; test_gzip_extra ()
+         ] )
+     ; ( "gzip with os"
+       , [
+           test_gzip_os Gz.FAT; test_gzip_os Gz.Amiga; test_gzip_os Gz.VMS
+         ; test_gzip_os Gz.Unix; test_gzip_os Gz.VM; test_gzip_os Gz.Atari
+         ; test_gzip_os Gz.HPFS; test_gzip_os Gz.Macintosh; test_gzip_os Gz.Z
+         ; test_gzip_os Gz.CPM; test_gzip_os Gz.TOPS20; test_gzip_os Gz.NTFS
+         ; test_gzip_os Gz.QDOS; test_gzip_os Gz.Acorn; test_gzip_os Gz.Unknown
+         ] )
+     ; ( "lzo"
+       , [
+           test_lzo_0 (); test_lzo_1 (); test_corpus_with_lzo "obj1"
+         ; test_corpus_with_lzo "obj2"; test_corpus_with_lzo "geo"
+         ; test_corpus_with_lzo "news"; test_corpus_with_lzo "pic"
+         ; test_corpus_with_lzo "progc"; test_corpus_with_lzo "progl"
+         ; test_corpus_with_lzo "progp"; test_corpus_with_lzo "trans"
+         ; test_corpus_with_lzo "paper1"; test_corpus_with_lzo "paper2"
+         ; test_corpus_with_lzo "book1"; test_corpus_with_lzo "book2"
+         ] ); "hang", [hang0 ()]; "git", [git_object ()]
+     ; ( "higher"
+       , [higher_zlib0 (); higher_zlib1 (); higher_zlib2 (); higher_zlib3 ()] )
+     ]
+    @ Test_ns.tests)

--- a/test/test_non_streamable.ml
+++ b/test/test_non_streamable.ml
@@ -505,6 +505,345 @@ let flat_and_fixed () =
   Alcotest.(check string) "deadbeefaaaa"
     expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
+let fuzz0 () =
+  Alcotest.test_case "fuzz0" `Quick @@ fun () ->
+  let src = bigstring_of_string "{\220\n s\017\027\211\\\006\211w\176`\142\2007\156oZBo\163\136\017\247\
+                                 \158\247\012e\241\234sn_$\210\223\017\213\138\147]\129M\137<\242\1867\021\
+                                 c\194\156\135\194\167-wo\006\200\198" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\xe3\x85" in
+  Alcotest.(check decode) "fuzz0"
+    (Ok (4, String.length expected))
+    res;
+  Alcotest.(check string) "0x00 * 33025"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz1 () =
+  Alcotest.test_case "fuzz1" `Quick @@ fun () ->
+  let src = bigstring_of_string "\019\208nO\200\189r\020\176" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\016+\135`m\212\197" in
+  Alcotest.(check decode) "fuzz1"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz1"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz2 () =
+  Alcotest.test_case "fuzz2" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x80\x51\x56\x3a\x01\x00\x00" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x1a\xca\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e" (* ..~~~~~~~~~~~~~~ *)
+    ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e" (* ~~~~~~~~~~~~~~~~ *)
+    ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e" (* ~~~~~~~~~~~~~~~~ *)
+    ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x3a\x2c\x50"                     (* ~~~~~~~~:,P *)      ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz2"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz2"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz3 () =
+  Alcotest.test_case "fuzz3" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x36\x0a\x01\x00\x00" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a" (* ..~..~..~..~..~. *)
+    ; "\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca" (* .~..~..~..~..~.. *)
+    ; "\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e" (* ~..~..~..~..~..~ *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76"                                                 (* .v.v *)             ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz3"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz3"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz4 () =
+  Alcotest.test_case "fuzz4" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x56\x0a\x06\x80\x00" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a" (* ..~..~..~..~..~. *)
+    ; "\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca" (* .~..~..~..~..~.. *)
+    ; "\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e" (* ~..~..~..~..~..~ *)
+    ; "\xc8\x76\x75\x75\x75\x75\x75\x75"                                 (* .vuuuuuu *)         ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz4"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz4"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz5 () =
+  Alcotest.test_case "fuzz5" `Quick @@ fun () ->
+  let src =
+    [ "\x93\x3a\x55\x01\x01\x01\x01\xe6\x01\x01\x01\x01\x01\x01\x01\x01" (* .:U............. *)
+    ; "\x01\x01\x01\x01\x01\x00\x00"                                     (* ....... *)          ] in
+  let src = bigstring_of_string (String.concat "" src) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x1a\xca\x78\x78\x78\x78\x78\x78\x78\x50\x50\x37\x50\x50\x50\x50" (* ..xxxxxxxPP7PPPP *)
+    ; "\x50\x50\x50\x50\x50\x50\x50\x50\x50"                             (* PPPPPPPPP *)        ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz5"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz5"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz6 () =
+  Alcotest.test_case "fuzz6" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x93\x8c\x8c\x8c\x8c\x7b\x8c\x8c\x8c\x01\x00\x00" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x19\x59\x59\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59" (* .YYY^.Y^.Y^.Y^.Y *)
+    ; "\x5e\xe3\x33"                                                     (* ^.3 *)              ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz6"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz6"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz7 () =
+  Alcotest.test_case "fuzz7" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x93\x3a\x55\x69\x12\x3a\x3f\x10\x08\x01\x00\x00" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\x1a\xca\x79\x34\x55\x9f\x51\x9f\x51\x9f" in
+  Alcotest.(check decode) "fuzz7"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz7"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz8 () =
+  Alcotest.test_case "fuzz8" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x7a\x37\x6d\x99\x13" in
+  Alcotest.(check decode) "fuzz8"
+    (Error Unexpected_end_of_input)
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let fuzz9 () =
+  Alcotest.test_case "fuzz9" `Quick @@ fun () ->
+  let src =
+    [ "\x9b\x01\x95\xfc\x51\xd2\xed\xc8\xce\xc8\xff\x80\x00\x00\x7f\xff" (* ....Q........... *)
+    ; "\x79\x2f\xe9\x51\x88\x7b\xb8\x2f\xef\xa5\x8c\xf8\xf1\xb6\xce\xc8" (* y/.Q.{./........ *)
+    ; "\xb8\xc8\xff\x2f\x00\x7f\x88\x7b\xbc"                             (* .../...{. *)        ] in
+  let src = bigstring_of_string (String.concat "" src) in
+  Alcotest.(check decode) "fuzz9"
+    (Error Invalid_distance)
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let fuzz10 () =
+  Alcotest.test_case "fuzz10" `Quick @@ fun () ->
+  let lst =
+    [ `Literal (Char.chr 231); `Literal (Char.chr 60); `Literal (Char.chr 128)
+    ; `Copy (1, 19); `End ] in
+  let src = bigstring_of_string (encode_dynamic lst) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  Alcotest.(check decode) "fuzz10"
+    (Ok (De.bigstring_length src, 22))
+    res
+
+let fuzz11 () =
+  Alcotest.test_case "fuzz11" `Quick @@ fun () ->
+  let lst =
+    [ `Literal (Char.chr 228)
+    ; `Literal (Char.chr 255)
+    ; `Copy (1, 130)
+    ; `End ] in
+  let src = bigstring_of_string (encode_dynamic lst) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\228" ^ String.make 131 '\xff' in
+  Alcotest.(check decode) "fuzz11"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz11"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz12 () =
+  Alcotest.test_case "fuzz12" `Quick @@ fun () ->
+  let lst =
+    [ `Literal (Char.chr 71)
+    ; `Literal (Char.chr 0)
+    ; `Literal (Char.chr 255)
+    ; `Copy (2, 249)
+    ; `End ] in
+  let src = bigstring_of_string (encode_dynamic lst) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x47\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* G............... *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"                 (* ............ *)
+    ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz12"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz12"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz13 () =
+  Alcotest.test_case "fuzz13" `Quick @@ fun () ->
+  let src =
+    [ "\x9b\x0e\x02\x00"                                                 (* .... *)
+    ] in
+  let src = bigstring_of_string (String.concat "" src) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\x97\x97\x97\x97\x97" in
+  Alcotest.(check decode) "fuzz13"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz13"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz14 () =
+  Alcotest.test_case "fuzz14" `Quick @@ fun () ->
+  let src =
+    [ "\x0b\xff\x7f\x0c\x0c\x8f\xcd\x0e\x02\x21\x64\x0c\x04\x73\xff\x80" (* .........!d..s.. *)
+    ; "\x20\x0c\x8f\x1c\x1c\x1c\x1c\x0c\x0c\x0c\x0c\x64\x1c\x7f\x0c\x0c" (*  ..........d.... *)
+    ; "\x8f\xcd\x0e\x02\x21\xff\xff\x80"                                 (* ....!... *)
+    ] in
+  let src = bigstring_of_string (String.concat "" src) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x57\xff\xc6\xff\xc6\xff\xc6\xff\xc6\x9b\x52\xc6\x9b\x52\xc6\xc6" (* W.........R..R.. *)
+    ; "\x9b\x52\xc6\xc6\x9b\x52\xc6\xc6\x9b\x52\xc6\xc6\xc6\xc6\x9d\xfc" (* .R...R...R...... *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x53\x53\x53\x9b\x52\xc6\x9b\x52\xc6\x9b" (* ......SSS.R..R.. *)
+    ; "\x52\xc6\x9b\x52\xc6\x9b\x52\xc6\x9b\x52\xc6\x9b\x52\x33\x5f\xc6" (* R..R..R..R..R3_. *)
+    ; "\x5f\xc6\x5f\xc6\x5f\xc6\x9b\x52\xc6\x9b\x52\xc6\x4f\xff"         (* _._._..R..R.O. *)
+    ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz14"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz14"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz15 () =
+  Alcotest.test_case "fuzz15" `Quick @@ fun () ->
+  let src =
+    [ "\x75\x85\xcd\x0e\x02\x21\x0c\x84\x3d\xf3\x14\x3d\xc2\x65\x63\xb2" (* u....!..=..=.ec. *)
+    ; "\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12\xe4\xe9\x5d\xa3\x28\x26" (* .d.i....X...].(& *)
+    ; "\xee\xad\xc2\x65\x63\xb2\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12" (* ...ec..d.i....X. *)
+    ; "\xe4\xe9\x5d\x66\xfb\xe8\x57\x57\x18\xf3\x5b\xdd\xcb\x73"         (* ..]f..WW..[..s *)
+    ] in
+  let src = bigstring_of_string (String.concat "" src) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x78\x20\x5f\x74\x6c\x69\x63"                                     (* x _tlic *)
+    ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz15"
+    (Ok (40, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz15"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz16 () =
+  Alcotest.test_case "fuzz16" `Quick @@ fun () ->
+  let lst = [ `Literal '@'
+            ; `Copy (1, 212)
+            ; `Copy (129, 258)
+            ; `Copy (7, 131)
+            ; `Copy (527, 208)
+            ; `Copy (129, 258)
+            ; `End ] in
+  let src = bigstring_of_string (encode_dynamic lst) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = String.make 1068 '@' in
+  Alcotest.(check decode) "fuzz16"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz16"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz17 () =
+  Alcotest.test_case "fuzz17" `Quick @@ fun () ->
+  let lst = [ `Literal (Char.chr 218); `Copy (1, 21); `Literal (Char.chr 190); `Literal (Char.chr 218); `Literal (Char.chr 0); `End ] in
+  let src = bigstring_of_string (encode_dynamic lst) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda" (* ................ *)
+    ; "\xda\xda\xda\xda\xda\xda\xbe\xda\x00"                             (* ......... *)
+    ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz17"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz17"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fuzz18 () =
+  Alcotest.test_case "fuzz18" `Quick @@ fun () ->
+  let src =
+    [ "\x75\x8f\xcd\x0e\x02\x21\x0c\x84\x3d\xf3\x14\x3d\xfc\x54\x63\xb2" (* u....!..=..=.Tc. *)
+    ; "\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12\xe4\xe9\x5d\xa3\x28\x26" (* .d.i....X...].(& *)
+    ; "\xee\xad\x33\xcd\xfc\x9d\x1a\x5e\x1e\xcc\xe7\xf9\x24\x99\x40\x06" (* ..3....^....$.@. *)
+    ; "\xed\x11\x4c\x56\xfb\xe8\x57\x57\x0a\xf3\x5b\xd9\xcb\x60\xd5\xd5" (* ..LV..WW..[..`.. *)
+    ] in
+  let src = bigstring_of_string (String.concat "" src) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected =
+    [ "\x75\x27\x5a\xfb\x64\x64\x2b\x63\x29\x67\x6e\x60\x20\x67\x6e\x60" (* u'dd+c)gn` gn` *)
+    ; "\x20\x67\x6e\x60\x5e\x28\x20\x5d\x6e\x0a\x63\x29\x67\x6e\x60\x20" (*  gn`^( ]n.c)gn`  *)
+    ; "\x67\x6e\x60\x20\x67\x6e\x63\x29\x67\x6e\x60\x20\x67\x73\x60\x69" (* gn` gnc)gn` gs`i *)
+    ; "\x63"                                                             (* c *)
+    ] in
+  let expected = String.concat "" expected in
+  Alcotest.(check decode) "fuzz18"
+    (Ok (60, String.length expected))
+    res;
+  Alcotest.(check string) "fuzz18"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
 let w0 = make_window ~bits:15
 let w1 = make_window ~bits:15
 let i = bigstring_create io_buffer_size
@@ -584,18 +923,37 @@ let tests =
                  ; max_flat ()
                  ; fixed_and_flat ()
                  ; flat_and_fixed () ]
-    ; "ns_calgary", [ test_corpus "bib"
-                    ; test_corpus "rfc5322.txt"
-                    ; test_corpus "book1"
-                    ; test_corpus "book2"
-                    ; test_corpus "geo"
-                    ; test_corpus "news"
-                    ; test_corpus "obj1"
-                    ; test_corpus "obj2"
-                    ; test_corpus "paper1"
-                    ; test_corpus "paper2"
-                    ; test_corpus "pic"
-                    ; test_corpus "progc"
-                    ; test_corpus "progl"
-                    ; test_corpus "progp"
-                    ; test_corpus "trans" ] ]
+  ; "ns_fuzz", [ fuzz0 ()
+               ; fuzz1 ()
+               ; fuzz2 ()
+               ; fuzz3 ()
+               ; fuzz4 ()
+               ; fuzz5 ()
+               ; fuzz6 ()
+               ; fuzz7 ()
+               ; fuzz8 ()
+               ; fuzz9 ()
+               ; fuzz10 ()
+               ; fuzz11 ()
+               ; fuzz12 ()
+               ; fuzz13 ()
+               ; fuzz14 ()
+               ; fuzz15 ()
+               ; fuzz16 ()
+               ; fuzz17 ()
+               ; fuzz18 () ]
+  ; "ns_calgary", [ test_corpus "bib"
+                  ; test_corpus "rfc5322.txt"
+                  ; test_corpus "book1"
+                  ; test_corpus "book2"
+                  ; test_corpus "geo"
+                  ; test_corpus "news"
+                  ; test_corpus "obj1"
+                  ; test_corpus "obj2"
+                  ; test_corpus "paper1"
+                  ; test_corpus "paper2"
+                  ; test_corpus "pic"
+                  ; test_corpus "progc"
+                  ; test_corpus "progl"
+                  ; test_corpus "progp"
+                  ; test_corpus "trans" ] ]

--- a/test/test_non_streamable.ml
+++ b/test/test_non_streamable.ml
@@ -1,0 +1,536 @@
+let seed = "kle6/0eMVRsY+AlbHjLTMQ=="
+
+let () =
+  let raw = Base64.decode_exn seed in
+  let res = Array.make 8 0 in
+  for i = 0 to 7 do res.(i) <- (Char.code raw.[i] lsl 8) lor (Char.code raw.[i + 1]) done ;
+  Random.full_init res
+
+let random len =
+  let res = Bytes.create len in
+  for i = 0 to len - 1 do Bytes.set res i (Char.chr (Random.int 256)) done ;
+  Bytes.unsafe_to_string res
+
+open De (* au detail *)
+
+external string_unsafe_get_uint32 : string -> int -> int32 = "%caml_string_get32"
+
+let string_unsafe_get_uint8 : string -> int -> int =
+  fun buf off -> Char.code (String.get buf off)
+
+external unsafe_set_uint8  : bigstring -> int -> int -> unit = "%caml_ba_set_1"
+external unsafe_set_uint32 : bigstring -> int -> int32 -> unit = "%caml_bigstring_set32"
+
+let bigstring_of_string v =
+  let len = String.length v in
+  let res = bigstring_create len in
+  let len0 = len land 3 in
+  let len1 = len asr 2 in
+
+  for i = 0 to len1 - 1
+  do
+    let i = i * 4 in
+    let v = string_unsafe_get_uint32 v i in
+    unsafe_set_uint32 res i v
+  done ;
+
+  for i = 0 to len0 - 1
+  do
+    let i = len1 * 4 + i in
+    let v = string_unsafe_get_uint8 v i in
+    unsafe_set_uint8 res i v
+  done ; res
+
+let w = make_window ~bits:15
+let src = bigstring_create io_buffer_size
+let dst = bigstring_create io_buffer_size
+let q = Queue.create 4096
+let wrkmem = Lzo.make_wrkmem ()
+
+let unsafe_get_uint8 b i = Char.code (Bigstringaf.get b i)
+let unsafe_get_uint32_be b i = Bigstringaf.get_int32_be b i
+
+let pp_chr =
+  Fmt.using (function '\032' .. '\126' as x -> x | _ -> '.') Fmt.char
+
+let pp_scalar : type buffer.
+    get:(buffer -> int -> char) -> length:(buffer -> int) -> buffer Fmt.t =
+ fun ~get ~length ppf b ->
+  let l = length b in
+  for i = 0 to l / 16 do
+    Fmt.pf ppf "%08x: " (i * 16) ;
+    let j = ref 0 in
+    while !j < 16 do
+      if (i * 16) + !j < l then
+        Fmt.pf ppf "%02x" (Char.code @@ get b ((i * 16) + !j))
+      else Fmt.pf ppf "  " ;
+      if !j mod 2 <> 0 then Fmt.pf ppf " " ;
+      incr j
+    done ;
+    Fmt.pf ppf "  " ;
+    j := 0 ;
+    while !j < 16 do
+      if (i * 16) + !j < l then Fmt.pf ppf "%a" pp_chr (get b ((i * 16) + !j))
+      else Fmt.pf ppf " " ;
+      incr j
+    done ;
+    Fmt.pf ppf "@\n"
+  done
+
+let pp_string = pp_scalar ~get:String.get ~length:String.length
+
+let str = Alcotest.testable pp_string String.equal
+
+let decode =
+  let pp ppf =
+    Fmt.result ppf
+      ~ok:(Fmt.pair ~sep:(Fmt.any ",") Fmt.int Fmt.int)
+      ~error:(Fmt.pair ~sep:(Fmt.any ",") Inf.Non_streamable.pp_error (Fmt.pair ~sep:(Fmt.any ",") Fmt.int Fmt.int))
+  in
+  let equal =
+    Result.equal
+      ~ok:
+        (fun (i1, o1) (i2, o2) -> Int.equal i1 i2 && Int.equal o1 o2)
+      ~error:
+        (fun (e1, (i1, o1)) (e2, (i2, o2)) -> e1 == e2 && Int.equal i1 i2 && Int.equal o1 o2)
+  in
+  Alcotest.testable pp equal
+
+let decode_i =
+  function
+  | Ok (v, _) -> v
+  | Error (_, (v, _)) -> v
+
+let decode_o =
+  function
+  | Ok (_, v) -> v
+  | Error (_, (_, v)) -> v
+
+let encode ~block:kind lst =
+  let res = Buffer.create 16 in
+  let q = Queue.of_list lst in
+  let encoder = Def.encoder (`Buffer res) ~q in
+  match Def.encode encoder (`Block { kind; last= true; }) with
+  | `Block -> assert false
+  | `Partial -> assert false
+  | `Ok -> match Def.encode encoder `Flush with
+    | `Ok -> Buffer.contents res
+    | `Block -> Alcotest.fail "Bad block"
+    | `Partial -> assert false
+
+let encode_dynamic lst =
+  let literals = make_literals () in
+  let distances = make_distances () in
+  List.iter
+    (function
+     | `Literal chr -> succ_literal literals chr
+     | `Copy (off, len) ->
+        succ_length literals len ;
+        succ_distance distances off
+     | _ -> ())
+    lst ;
+  let dynamic = Def.dynamic_of_frequencies ~literals ~distances in
+  encode ~block:(Def.Dynamic dynamic) lst
+
+let invalid_complement_of_length () =
+  Alcotest.test_case "invalid complement of length" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x00\x00\x00\x00\x00" in
+  Alcotest.(check decode) "invalid complement of length"
+    (Error (Invalid_complement_of_length, (5, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let invalid_kind_of_block () =
+  Alcotest.test_case "invalid kind of block" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x06" in
+  Alcotest.(check decode) "invalid kind of block"
+    (Error (Invalid_kind_of_block, (1, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let invalid_code_lengths () =
+  Alcotest.test_case "invalid code lengths" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x04\x00\xfe\xff" in
+  Alcotest.(check decode) "invalid code lengths"
+    (Error (Invalid_dictionary, (4, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let invalid_bit_length_repeat () =
+  Alcotest.test_case "invalid bit length repeat" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x04\x00\x24\x49\x00" in
+  Alcotest.(check decode) "invalid bit length repeat"
+    (Error (Invalid_dictionary, (4, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let invalid_codes () =
+  Alcotest.test_case "invalid codes -- missing end-of-block" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x04\x00\x24\xe9\xff\x6d" in
+  Alcotest.(check decode) "invalid codes -- missing end-of-block"
+    (Error (Invalid_dictionary, (6, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let invalid_lengths () =
+  Alcotest.test_case "invalid literals/lengths" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x04\x80\x49\x92\x24\x49\x92\x24\x49\x92\x24\x71\xff\xff\x93\x11\x00" in
+  Alcotest.(check decode) "invalid literals/lengths"
+    (Error (Invalid_dictionary, (16, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let invalid_distances () =
+  Alcotest.test_case "invalid distances" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x04\x80\x49\x92\x24\x49\x92\x24\x0f\xb4\xff\xff\xc3\x84" in
+  Alcotest.(check decode) "invalid distances"
+    (Error (Invalid_dictionary, (14, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let too_many_length_or_distance_symbols () =
+  Alcotest.test_case "too many length of distance symbols" `Quick @@ fun () ->
+  let src = bigstring_of_string "\xfc\x00\x00" in
+  Alcotest.(check decode) "too many length of distance symbols"
+    (Error (Unexpected_end_of_input, (3, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+(* XXX(dinosaure): error is not conform to what we expect (best will be [Invalid
+   dictionary]), TODO! *)
+
+let invalid_distance_code () =
+  Alcotest.test_case "invalid distance code" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x02\x7e\xff\xff" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  Alcotest.(check decode) "invalid distance code"
+    (Error (Invalid_distance_code, (2, 0)))
+    res;
+  Alcotest.(check string) "non-corrupted output"
+    "" (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+(* XXX(dinosaure): see [Inf.base_dist]'s comment about this behavior. *)
+
+let invalid_distance_too_far_back () =
+  Alcotest.test_case "invalid distance too far back" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x0c\xc0\x81\x00\x00\x00\x00\x00\x90\xff\x6b\x04\x00" in
+  Alcotest.(check decode) "invalid distance too far back"
+    (Error (Invalid_distance, (12, 0)))
+    (Inf.Non_streamable.inflate ~src ~dst ~w)
+
+let fixed () =
+  Alcotest.test_case "fixed" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x03\x00" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "" in
+  Alcotest.(check decode) "fixed"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "empty"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let stored () =
+  Alcotest.test_case "stored" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x01\x01\x00\xfe\xff\x00" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\x00" in
+  Alcotest.(check decode) "stored"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "0x00"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let length_extra () =
+  Alcotest.test_case "length extra" `Quick @@ fun () ->
+  let src = bigstring_of_string "\xed\xc0\x01\x01\x00\x00\x00\x40\x20\xff\x57\x1b\x42\x2c\x4f" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = String.make 516 '\x00' in
+  Alcotest.(check decode) "length extra"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "0x00 * 516"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let long_distance_and_extra () =
+  Alcotest.test_case "long distance and extra" `Quick @@ fun () ->
+  let src = bigstring_of_string "\xed\xcf\xc1\xb1\x2c\x47\x10\xc4\x30\xfa\x6f\x35\x1d\x01\x82\x59\x3d\xfb\
+                                      \xbe\x2e\x2a\xfc\x0f\x0c" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = String.make 518 '\x00' in
+  Alcotest.(check decode) "long distance and extra"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "0x00 * 518"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let window_end () =
+  Alcotest.test_case "window end" `Quick @@ fun () ->
+  let src = bigstring_of_string "\xed\xc0\x81\x00\x00\x00\x00\x80\xa0\xfd\xa9\x17\xa9\x00\x00\x00\x00\x00\
+                                      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+                                      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x06" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = String.make 33025 '\x00' in
+  Alcotest.(check decode) "window end"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "0x00 * 33025"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let flat_of_string () =
+  Alcotest.test_case "flat of string" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x01\x00\x00\xff\xff" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "" in
+  Alcotest.(check decode) "flat of string"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "empty"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let flat_block () =
+  Alcotest.test_case "flat block" `Quick @@ fun () ->
+  let src = bigstring_of_string "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\xde\xad\xbe\xef" in
+  Alcotest.(check decode) "flat block"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "deadbeef"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let huffman_length_extra () =
+  Alcotest.test_case "huffman length extra" `Quick @@ fun () ->
+  let literals = make_literals () in
+  succ_literal literals '\000' ;
+  succ_literal literals '\000' ;
+  succ_length literals 258 ;
+  succ_length literals 256 ;
+  let distances = make_distances () in
+  succ_distance distances 1 ;
+  succ_distance distances 1 ;
+  let dynamic = Def.dynamic_of_frequencies ~literals ~distances in
+  let res = encode ~block:(Def.Dynamic dynamic) [ `Literal '\000'
+                                                ; `Literal '\000'
+                                                ; `Copy (1, 258)
+                                                ; `Copy (1, 256)
+                                                ; `End ] in
+  Alcotest.(check str) "encoding" res "\237\193\001\001\000\000\000@ \255W\027B\193\234\004" ;
+
+  let src = bigstring_of_string res in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = String.make (258 + 256 + 2) '\000' in
+  Alcotest.(check decode) "huffman length extra"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check str) "result"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let ( <.> ) f g = fun x -> f (g x)
+
+let dynamic_and_fixed () =
+  Alcotest.test_case "dynamic+fixed" `Quick @@ fun () ->
+  let res = Buffer.create 16 in
+  let literals = make_literals () in
+  let distances = make_distances () in
+  Queue.reset q ;
+  List.iter (Queue.push_exn q <.> Queue.cmd) [ `Literal 'a'; `Copy (1, 3) ] ;
+  succ_literal literals 'a' ;
+  succ_length literals 3 ;
+  succ_distance distances 1 ;
+  let dynamic_a = Def.dynamic_of_frequencies ~literals ~distances in
+  let encoder = Def.encoder (`Buffer res) ~q in
+  let rec go = function
+    | [] -> ()
+    | `Fill lst :: r ->
+      Alcotest.(check bool) "empty queue" (Queue.is_empty q) true ;
+      List.iter (Queue.push_exn q <.> Queue.cmd) lst ; go r
+    | #Def.encode as x :: r -> match Def.encode encoder x with
+      | `Partial -> Alcotest.fail "Impossible `Partial case"
+      | `Block -> Alcotest.fail "Impossible `Block case"
+      | `Ok -> go r in
+  go [ `Block { Def.kind= Def.Dynamic dynamic_a; Def.last= false; }
+     ; `Flush
+     ; `Fill [ `Literal 'b'; `Copy (1, 3); `End ]
+     ; `Block { Def.kind= Def.Fixed; Def.last= true; }
+     ; `Flush ] ;
+  let src = bigstring_of_string (Buffer.contents res) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "aaaabbbb" in
+  Alcotest.(check decode) "dynamic+fixed"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check str) "result"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fixed_and_dynamic () =
+  Alcotest.test_case "fixed+dynamic" `Quick @@ fun () ->
+  let res = Buffer.create 16 in
+  let literals = make_literals () in
+  let distances = make_distances () in
+  Queue.reset q ;
+  List.iter (Queue.push_exn q <.> Queue.cmd) [ `Literal 'a'; `Copy (1, 3) ] ;
+  succ_literal literals 'b' ;
+  succ_length literals 3 ;
+  succ_distance distances 1 ;
+  let dynamic_b = Def.dynamic_of_frequencies ~literals ~distances in
+  let encoder = Def.encoder (`Buffer res) ~q in
+  let rec go = function
+    | [] -> ()
+    | `Fill lst :: r ->
+      Alcotest.(check bool) "empty queue" (Queue.is_empty q) true ;
+      List.iter (Queue.push_exn q <.> Queue.cmd) lst ; go r
+    | #Def.encode as x :: r -> match Def.encode encoder x with
+      | `Partial -> Alcotest.fail "Impossible `Partial case"
+      | `Block -> Alcotest.fail "Impossible `Block case"
+      | `Ok -> go r in
+  go [ `Flush
+     ; `Block { Def.kind= Def.Dynamic dynamic_b; last= true; }
+     ; `Fill [ `Literal 'b'; `Copy (1, 3); `End ]
+     ; `Flush ] ;
+  Fmt.epr "> %S.\n%!" (Buffer.contents res) ;
+  let src = bigstring_of_string (Buffer.contents res) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "aaaabbbb" in
+  Alcotest.(check decode) "fixed+dynamic"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check str) "result"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let dynamic_and_dynamic () =
+  Alcotest.test_case "dynamic+dynamic" `Quick @@ fun () ->
+  let res = Buffer.create 16 in
+  let literals = make_literals () in
+  let distances = make_distances () in
+  Queue.reset q ;
+  List.iter (Queue.push_exn q <.> Queue.cmd) [ `Literal 'a'; `Copy (1, 3); `Literal 'b'; `Copy (1, 3); `End ] ;
+
+  succ_literal literals 'a' ;
+  succ_length literals 3 ;
+  succ_distance distances 1 ;
+  let dynamic_a = Def.dynamic_of_frequencies ~literals ~distances in
+  succ_literal literals 'b' ;
+  succ_length literals 3 ;
+  succ_distance distances 1 ;
+  let dynamic_b = Def.dynamic_of_frequencies ~literals ~distances in
+
+  let encoder = Def.encoder (`Buffer res) ~q in
+  let rec go = function
+    | [] -> ()
+    | x :: `Block block :: r ->
+      ( match Def.encode encoder x with
+        | `Partial -> Alcotest.fail "Impossible `Partial case"
+        | `Block -> go ((`Block block) :: r)
+        | `Ok -> Alcotest.fail "Unexpected `Ok case" )
+    | x :: r -> match Def.encode encoder x with
+      | `Ok -> go r
+      | `Partial -> Alcotest.fail "Impossible `Partial case"
+      | `Block -> Alcotest.fail "Impossible `Block case" in
+  go [ `Block { Def.kind= Def.Dynamic dynamic_a; Def.last= false; }
+     ; `Block { Def.kind= Def.Dynamic dynamic_b; Def.last= true; }
+     ; `Flush ] ;
+
+  Fmt.epr "> %S.\n%!" (Buffer.contents res) ;
+  let src = bigstring_of_string (Buffer.contents res) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "aaaabbbb" in
+  Alcotest.(check decode) "dynamic+dynamic"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check str) "result"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let max_flat () =
+  Alcotest.test_case "biggest flat block" `Quick @@ fun () ->
+  let inputs = Bytes.make (0xFFFF + 1 + 4) '\x00' in
+  Bytes.set inputs 0 '\x01' ; (* last *)
+  Bytes.set inputs 1 '\xff' ; Bytes.set inputs 2 '\xff' ; (* len *)
+  let src = bigstring_of_string (Bytes.unsafe_to_string inputs) in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = String.make 0xffff '\x00' in
+  Alcotest.(check decode) "biggest flat block"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "0xffff * \x00"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let flat () =
+  Alcotest.test_case "encode flat" `Quick @@ fun () ->
+  let q = Queue.of_list [ `Literal '\xDE'; `Literal '\xAD'; `Literal '\xBE'; `Literal '\xEF' ] in
+  let b = Buffer.create 16 in
+  let encoder = Def.encoder (`Buffer b) ~q in
+
+  let go = function
+    | `Ok -> Buffer.contents b
+    | `Partial | `Block -> assert false in
+  let res0 = go (Def.encode encoder (`Block { Def.kind= Def.Flat 4; last= true; })) in
+  Alcotest.(check string) "deadbeef deflated" "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" res0 ;
+  let src = bigstring_of_string res0 in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\xde\xad\xbe\xef" in
+  Alcotest.(check decode) "encode flat"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "deadbeef"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let fixed_and_flat () =
+  Alcotest.test_case "fixed+flat" `Quick @@ fun () ->
+  let q = Queue.of_list [ `Literal 'a'; `Copy (1, 3); `End; `Literal '\xDE'; `Literal '\xAD'; `Literal '\xBE'; `Literal '\xEF' ] in
+  let b = Buffer.create 16 in
+  let encoder = Def.encoder (`Buffer b) ~q in
+
+  let rec go = function
+    | `Ok -> Buffer.contents b
+    | `Partial -> assert false
+    | `Block ->
+      go (Def.encode encoder (`Block { Def.kind= Def.Flat (Queue.length q); last= true; })) in
+  let res0 = go (Def.encode encoder `Flush) in
+  let src = bigstring_of_string res0 in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "aaaa\xde\xad\xbe\xef" in
+  Alcotest.(check decode) "fixed+flat"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "aaaadeadbeef"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let flat_and_fixed () =
+  Alcotest.test_case "flat+fixed" `Quick @@ fun () ->
+  let q = Queue.of_list [ `Literal '\xDE'; `Literal '\xAD'; `Literal '\xBE'; `Literal '\xEF'; `Literal 'a'; `Copy (1, 3); `End ] in
+  let b = Buffer.create 16 in
+  let encoder = Def.encoder (`Buffer b) ~q in
+
+  let rec go = function
+    | `Ok -> Buffer.contents b
+    | `Partial -> assert false
+    | `Block ->
+      go (Def.encode encoder (`Block { Def.kind= Def.Fixed; last= true; })) in
+  let res0 = go (Def.encode encoder (`Block { Def.kind= Def.Flat 4; last= false; })) in
+
+  let src = bigstring_of_string res0 in
+  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let expected = "\xde\xad\xbe\xefaaaa" in
+  Alcotest.(check decode) "flat+fixed"
+    (Ok (De.bigstring_length src, String.length expected))
+    res;
+  Alcotest.(check string) "deadbeefaaaa"
+    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+
+let tests =
+  [ "ns_invalids", [ invalid_complement_of_length ()
+                ; invalid_kind_of_block ()
+                ; invalid_code_lengths ()
+                ; invalid_bit_length_repeat ()
+                ; invalid_codes ()
+                ; invalid_lengths ()
+                ; invalid_distances ()
+                ; too_many_length_or_distance_symbols ()
+                ; invalid_distance_code ()
+                ; invalid_distance_too_far_back () ]
+  ; "ns_valids", [ fixed ()
+              ; stored ()
+              ; length_extra ()
+              ; long_distance_and_extra ()
+              ; window_end ()
+              ; huffman_length_extra ()
+              ; dynamic_and_fixed ()
+              ; fixed_and_dynamic ()
+              ; dynamic_and_dynamic ()
+              ; flat_of_string ()
+              ; flat_block ()
+              ; flat ()
+              ; max_flat ()
+              ; fixed_and_flat ()
+              ; flat_and_fixed () ] ]

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -85,7 +85,7 @@ let decode =
   let pp ppf =
     Fmt.result ppf
       ~ok:(Fmt.pair ~sep:(Fmt.any ",") Fmt.int Fmt.int)
-      ~error:Inf.Non_streamable.pp_error
+      ~error:Inf.Ns.pp_error
   in
   let equal =
     Result.equal
@@ -137,56 +137,56 @@ let invalid_complement_of_length () =
   let src = bigstring_of_string "\x00\x00\x00\x00\x00" in
   Alcotest.(check decode) "invalid complement of length"
     (Error Invalid_complement_of_length)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_kind_of_block () =
   Alcotest.test_case "invalid kind of block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x06" in
   Alcotest.(check decode) "invalid kind of block"
     (Error Invalid_kind_of_block)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_code_lengths () =
   Alcotest.test_case "invalid code lengths" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\xfe\xff" in
   Alcotest.(check decode) "invalid code lengths"
     (Error Invalid_dictionary)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_bit_length_repeat () =
   Alcotest.test_case "invalid bit length repeat" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\x24\x49\x00" in
   Alcotest.(check decode) "invalid bit length repeat"
     (Error Invalid_dictionary)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_codes () =
   Alcotest.test_case "invalid codes -- missing end-of-block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\x24\xe9\xff\x6d" in
   Alcotest.(check decode) "invalid codes -- missing end-of-block"
     (Error Invalid_dictionary)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_lengths () =
   Alcotest.test_case "invalid literals/lengths" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x80\x49\x92\x24\x49\x92\x24\x49\x92\x24\x71\xff\xff\x93\x11\x00" in
   Alcotest.(check decode) "invalid literals/lengths"
     (Error Invalid_dictionary)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_distances () =
   Alcotest.test_case "invalid distances" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x80\x49\x92\x24\x49\x92\x24\x0f\xb4\xff\xff\xc3\x84" in
   Alcotest.(check decode) "invalid distances"
     (Error Invalid_dictionary)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let too_many_length_or_distance_symbols () =
   Alcotest.test_case "too many length of distance symbols" `Quick @@ fun () ->
   let src = bigstring_of_string "\xfc\x00\x00" in
   Alcotest.(check decode) "too many length of distance symbols"
     (Error Unexpected_end_of_input)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 (* XXX(dinosaure): error is not conform to what we expect (best will be [Invalid
    dictionary]), TODO! *)
 
@@ -195,7 +195,7 @@ let invalid_distance_code () =
   let src = bigstring_of_string "\x02\x7e\xff\xff" in
   Alcotest.(check decode) "invalid distance code"
     (Error Invalid_distance_code)
-    (Inf.Non_streamable.inflate ~src ~dst ~ w)
+    (Inf.Ns.inflate ~src ~dst ~ w)
 
 (* XXX(dinosaure): see [Inf.base_dist]'s comment about this behavior. *)
 
@@ -204,12 +204,12 @@ let invalid_distance_too_far_back () =
   let src = bigstring_of_string "\x0c\xc0\x81\x00\x00\x00\x00\x00\x90\xff\x6b\x04\x00" in
   Alcotest.(check decode) "invalid distance too far back"
     (Error Invalid_distance)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let fixed () =
   Alcotest.test_case "fixed" `Quick @@ fun () ->
   let src = bigstring_of_string "\x03\x00" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "" in
   Alcotest.(check decode) "fixed"
     (Ok (De.bigstring_length src, String.length expected))
@@ -220,7 +220,7 @@ let fixed () =
 let stored () =
   Alcotest.test_case "stored" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x01\x00\xfe\xff\x00" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\x00" in
   Alcotest.(check decode) "stored"
     (Ok (De.bigstring_length src, String.length expected))
@@ -231,7 +231,7 @@ let stored () =
 let length_extra () =
   Alcotest.test_case "length extra" `Quick @@ fun () ->
   let src = bigstring_of_string "\xed\xc0\x01\x01\x00\x00\x00\x40\x20\xff\x57\x1b\x42\x2c\x4f" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = String.make 516 '\x00' in
   Alcotest.(check decode) "length extra"
     (Ok (De.bigstring_length src, String.length expected))
@@ -243,7 +243,7 @@ let long_distance_and_extra () =
   Alcotest.test_case "long distance and extra" `Quick @@ fun () ->
   let src = bigstring_of_string "\xed\xcf\xc1\xb1\x2c\x47\x10\xc4\x30\xfa\x6f\x35\x1d\x01\x82\x59\x3d\xfb\
                                       \xbe\x2e\x2a\xfc\x0f\x0c" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = String.make 518 '\x00' in
   Alcotest.(check decode) "long distance and extra"
     (Ok (De.bigstring_length src, String.length expected))
@@ -256,7 +256,7 @@ let window_end () =
   let src = bigstring_of_string "\xed\xc0\x81\x00\x00\x00\x00\x80\xa0\xfd\xa9\x17\xa9\x00\x00\x00\x00\x00\
                                       \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
                                       \x00\x00\x00\x00\x00\x00\x00\x00\x00\x06" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = String.make 33025 '\x00' in
   Alcotest.(check decode) "window end"
     (Ok (De.bigstring_length src, String.length expected))
@@ -267,7 +267,7 @@ let window_end () =
 let flat_of_string () =
   Alcotest.test_case "flat of string" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x00\x00\xff\xff" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "" in
   Alcotest.(check decode) "flat of string"
     (Ok (De.bigstring_length src, String.length expected))
@@ -278,7 +278,7 @@ let flat_of_string () =
 let flat_block () =
   Alcotest.test_case "flat block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\xde\xad\xbe\xef" in
   Alcotest.(check decode) "flat block"
     (Ok (De.bigstring_length src, String.length expected))
@@ -305,7 +305,7 @@ let huffman_length_extra () =
   Alcotest.(check str) "encoding" res "\237\193\001\001\000\000\000@ \255W\027B\193\234\004" ;
 
   let src = bigstring_of_string res in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = String.make (258 + 256 + 2) '\000' in
   Alcotest.(check decode) "huffman length extra"
     (Ok (De.bigstring_length src, String.length expected))
@@ -342,7 +342,7 @@ let dynamic_and_fixed () =
      ; `Block { Def.kind= Def.Fixed; Def.last= true; }
      ; `Flush ] ;
   let src = bigstring_of_string (Buffer.contents res) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "aaaabbbb" in
   Alcotest.(check decode) "dynamic+fixed"
     (Ok (De.bigstring_length src, String.length expected))
@@ -377,7 +377,7 @@ let fixed_and_dynamic () =
      ; `Flush ] ;
   Fmt.epr "> %S.\n%!" (Buffer.contents res) ;
   let src = bigstring_of_string (Buffer.contents res) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "aaaabbbb" in
   Alcotest.(check decode) "fixed+dynamic"
     (Ok (De.bigstring_length src, String.length expected))
@@ -420,7 +420,7 @@ let dynamic_and_dynamic () =
 
   Fmt.epr "> %S.\n%!" (Buffer.contents res) ;
   let src = bigstring_of_string (Buffer.contents res) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "aaaabbbb" in
   Alcotest.(check decode) "dynamic+dynamic"
     (Ok (De.bigstring_length src, String.length expected))
@@ -434,7 +434,7 @@ let max_flat () =
   Bytes.set inputs 0 '\x01' ; (* last *)
   Bytes.set inputs 1 '\xff' ; Bytes.set inputs 2 '\xff' ; (* len *)
   let src = bigstring_of_string (Bytes.unsafe_to_string inputs) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = String.make 0xffff '\x00' in
   Alcotest.(check decode) "biggest flat block"
     (Ok (De.bigstring_length src, String.length expected))
@@ -454,7 +454,7 @@ let flat () =
   let res0 = go (Def.encode encoder (`Block { Def.kind= Def.Flat 4; last= true; })) in
   Alcotest.(check string) "deadbeef deflated" "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" res0 ;
   let src = bigstring_of_string res0 in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\xde\xad\xbe\xef" in
   Alcotest.(check decode) "encode flat"
     (Ok (De.bigstring_length src, String.length expected))
@@ -475,7 +475,7 @@ let fixed_and_flat () =
       go (Def.encode encoder (`Block { Def.kind= Def.Flat (Queue.length q); last= true; })) in
   let res0 = go (Def.encode encoder `Flush) in
   let src = bigstring_of_string res0 in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "aaaa\xde\xad\xbe\xef" in
   Alcotest.(check decode) "fixed+flat"
     (Ok (De.bigstring_length src, String.length expected))
@@ -497,7 +497,7 @@ let flat_and_fixed () =
   let res0 = go (Def.encode encoder (`Block { Def.kind= Def.Flat 4; last= false; })) in
 
   let src = bigstring_of_string res0 in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\xde\xad\xbe\xefaaaa" in
   Alcotest.(check decode) "flat+fixed"
     (Ok (De.bigstring_length src, String.length expected))
@@ -510,7 +510,7 @@ let fuzz0 () =
   let src = bigstring_of_string "{\220\n s\017\027\211\\\006\211w\176`\142\2007\156oZBo\163\136\017\247\
                                  \158\247\012e\241\234sn_$\210\223\017\213\138\147]\129M\137<\242\1867\021\
                                  c\194\156\135\194\167-wo\006\200\198" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\xe3\x85" in
   Alcotest.(check decode) "fuzz0"
     (Ok (4, String.length expected))
@@ -521,7 +521,7 @@ let fuzz0 () =
 let fuzz1 () =
   Alcotest.test_case "fuzz1" `Quick @@ fun () ->
   let src = bigstring_of_string "\019\208nO\200\189r\020\176" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\016+\135`m\212\197" in
   Alcotest.(check decode) "fuzz1"
     (Ok (De.bigstring_length src, String.length expected))
@@ -532,7 +532,7 @@ let fuzz1 () =
 let fuzz2 () =
   Alcotest.test_case "fuzz2" `Quick @@ fun () ->
   let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x80\x51\x56\x3a\x01\x00\x00" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x1a\xca\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e" (* ..~~~~~~~~~~~~~~ *)
     ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e" (* ~~~~~~~~~~~~~~~~ *)
@@ -548,7 +548,7 @@ let fuzz2 () =
 let fuzz3 () =
   Alcotest.test_case "fuzz3" `Quick @@ fun () ->
   let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x36\x0a\x01\x00\x00" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a" (* ..~..~..~..~..~. *)
     ; "\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca" (* .~..~..~..~..~.. *)
@@ -580,7 +580,7 @@ let fuzz3 () =
 let fuzz4 () =
   Alcotest.test_case "fuzz4" `Quick @@ fun () ->
   let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x56\x0a\x06\x80\x00" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a" (* ..~..~..~..~..~. *)
     ; "\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca" (* .~..~..~..~..~.. *)
@@ -599,7 +599,7 @@ let fuzz5 () =
     [ "\x93\x3a\x55\x01\x01\x01\x01\xe6\x01\x01\x01\x01\x01\x01\x01\x01" (* .:U............. *)
     ; "\x01\x01\x01\x01\x01\x00\x00"                                     (* ....... *)          ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x1a\xca\x78\x78\x78\x78\x78\x78\x78\x50\x50\x37\x50\x50\x50\x50" (* ..xxxxxxxPP7PPPP *)
     ; "\x50\x50\x50\x50\x50\x50\x50\x50\x50"                             (* PPPPPPPPP *)        ] in
@@ -613,7 +613,7 @@ let fuzz5 () =
 let fuzz6 () =
   Alcotest.test_case "fuzz6" `Quick @@ fun () ->
   let src = bigstring_of_string "\x93\x8c\x8c\x8c\x8c\x7b\x8c\x8c\x8c\x01\x00\x00" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x19\x59\x59\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59" (* .YYY^.Y^.Y^.Y^.Y *)
     ; "\x5e\xe3\x33"                                                     (* ^.3 *)              ] in
@@ -627,7 +627,7 @@ let fuzz6 () =
 let fuzz7 () =
   Alcotest.test_case "fuzz7" `Quick @@ fun () ->
   let src = bigstring_of_string "\x93\x3a\x55\x69\x12\x3a\x3f\x10\x08\x01\x00\x00" in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\x1a\xca\x79\x34\x55\x9f\x51\x9f\x51\x9f" in
   Alcotest.(check decode) "fuzz7"
     (Ok (De.bigstring_length src, String.length expected))
@@ -640,7 +640,7 @@ let fuzz8 () =
   let src = bigstring_of_string "\x7a\x37\x6d\x99\x13" in
   Alcotest.(check decode) "fuzz8"
     (Error Unexpected_end_of_input)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let fuzz9 () =
   Alcotest.test_case "fuzz9" `Quick @@ fun () ->
@@ -651,7 +651,7 @@ let fuzz9 () =
   let src = bigstring_of_string (String.concat "" src) in
   Alcotest.(check decode) "fuzz9"
     (Error Invalid_distance)
-    (Inf.Non_streamable.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 let fuzz10 () =
   Alcotest.test_case "fuzz10" `Quick @@ fun () ->
@@ -659,7 +659,7 @@ let fuzz10 () =
     [ `Literal (Char.chr 231); `Literal (Char.chr 60); `Literal (Char.chr 128)
     ; `Copy (1, 19); `End ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   Alcotest.(check decode) "fuzz10"
     (Ok (De.bigstring_length src, 22))
     res
@@ -672,7 +672,7 @@ let fuzz11 () =
     ; `Copy (1, 130)
     ; `End ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\228" ^ String.make 131 '\xff' in
   Alcotest.(check decode) "fuzz11"
     (Ok (De.bigstring_length src, String.length expected))
@@ -689,7 +689,7 @@ let fuzz12 () =
     ; `Copy (2, 249)
     ; `End ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x47\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* G............... *)
     ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
@@ -721,7 +721,7 @@ let fuzz13 () =
     [ "\x9b\x0e\x02\x00"                                                 (* .... *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = "\x97\x97\x97\x97\x97" in
   Alcotest.(check decode) "fuzz13"
     (Ok (De.bigstring_length src, String.length expected))
@@ -737,7 +737,7 @@ let fuzz14 () =
     ; "\x8f\xcd\x0e\x02\x21\xff\xff\x80"                                 (* ....!... *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x57\xff\xc6\xff\xc6\xff\xc6\xff\xc6\x9b\x52\xc6\x9b\x52\xc6\xc6" (* W.........R..R.. *)
     ; "\x9b\x52\xc6\xc6\x9b\x52\xc6\xc6\x9b\x52\xc6\xc6\xc6\xc6\x9d\xfc" (* .R...R...R...... *)
@@ -776,7 +776,7 @@ let fuzz15 () =
     ; "\xe4\xe9\x5d\x66\xfb\xe8\x57\x57\x18\xf3\x5b\xdd\xcb\x73"         (* ..]f..WW..[..s *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x78\x20\x5f\x74\x6c\x69\x63"                                     (* x _tlic *)
     ] in
@@ -797,7 +797,7 @@ let fuzz16 () =
             ; `Copy (129, 258)
             ; `End ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected = String.make 1068 '@' in
   Alcotest.(check decode) "fuzz16"
     (Ok (De.bigstring_length src, String.length expected))
@@ -809,7 +809,7 @@ let fuzz17 () =
   Alcotest.test_case "fuzz17" `Quick @@ fun () ->
   let lst = [ `Literal (Char.chr 218); `Copy (1, 21); `Literal (Char.chr 190); `Literal (Char.chr 218); `Literal (Char.chr 0); `End ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda" (* ................ *)
     ; "\xda\xda\xda\xda\xda\xda\xbe\xda\x00"                             (* ......... *)
@@ -830,7 +830,7 @@ let fuzz18 () =
     ; "\xed\x11\x4c\x56\xfb\xe8\x57\x57\x0a\xf3\x5b\xd9\xcb\x60\xd5\xd5" (* ..LV..WW..[..`.. *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Non_streamable.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~ w in
   let expected =
     [ "\x75\x27\x5a\xfb\x64\x64\x2b\x63\x29\x67\x6e\x60\x20\x67\x6e\x60" (* u'dd+c)gn` gn` *)
     ; "\x20\x67\x6e\x60\x5e\x28\x20\x5d\x6e\x0a\x63\x29\x67\x6e\x60\x20" (*  gn`^( ]n.c)gn`  *)
@@ -873,7 +873,7 @@ let compress_and_uncompress ic =
   let src = bigstring_of_string (Bytes.to_string (Buffer.to_bytes b)) in
   let dst = bigstring_create (in_channel_length ic) in
 
-  match Inf.Non_streamable.inflate ~src ~dst ~w:w1 with
+  match Inf.Ns.inflate ~src ~dst ~w:w1 with
   | Ok (_, l) ->
     Stdlib.seek_in ic 0 ;
     Buffer.clear b;
@@ -890,7 +890,7 @@ let compress_and_uncompress ic =
         if pos <> String.length contents
         then Fmt.invalid_arg "Lengths differ: (contents: %d, file: %d)" (String.length contents) pos in
     slow_compare 0
-  | Error err -> Alcotest.failf "Error when inflating: %a" Inf.Non_streamable.pp_error err
+  | Error err -> Alcotest.failf "Error when inflating: %a" Inf.Ns.pp_error err
 
 let test_corpus filename =
   Alcotest.test_case filename `Slow @@ fun () ->

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -99,7 +99,9 @@ let check_decode =
     | _ -> false in
   Alcotest.testable pp equal
 
-let check_decode_o = function Ok (_, v) -> v | Error _ -> raise Alcotest.Test_error
+let check_decode_o = function
+  | Ok (_, v) -> v
+  | Error _ -> raise Alcotest.Test_error
 
 let check_encode = function Ok v -> v | Error _ -> raise Alcotest.Test_error
 
@@ -1157,9 +1159,13 @@ let encoder_0 () =
   let src = bigstring_of_string "\x00" in
   let res = Def.Ns.deflate ~level:0 src dst in
   let expected = "\x01\x01\x00\xfe\xff\x00" in
-  Alcotest.(check (result int Alcotest.reject)) "encoder 0" (Ok (String.length expected)) res
+  Alcotest.(check (result int Alcotest.reject))
+    "encoder 0"
+    (Ok (String.length expected))
+    res
   ; ( Bigstringaf.to_string dst |> fun s ->
-      String.sub s 0 (check_encode res) |> String.iteri (fun i -> Fmt.pr "%d: %C\n%!" i) )
+      String.sub s 0 (check_encode res)
+      |> String.iteri (fun i -> Fmt.pr "%d: %C\n%!" i) )
   ; Alcotest.(check string)
       "0x00" expected
       (Bigstringaf.substring dst ~off:0 ~len:(check_encode res))
@@ -1178,7 +1184,10 @@ let encoder_1 () =
   let src = bigstring_of_string (String.concat "" src) in
   let res = Def.Ns.deflate ~level:1 src dst in
   let expected = "\x63\x20\x13\x00\x00" in
-  Alcotest.(check (result int Alcotest.reject)) "encoder 1" (Ok (String.length expected)) res
+  Alcotest.(check (result int Alcotest.reject))
+    "encoder 1"
+    (Ok (String.length expected))
+    res
   ; ( Bigstringaf.to_string dst |> fun s ->
       String.sub s 0 (check_encode res)
       |> String.iteri (fun i j -> Fmt.pr "%d: \\x%02x\n%!" i (Char.code j)) )

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -84,16 +84,13 @@ let str = Alcotest.testable pp_string String.equal
 let decode =
   let pp ppf =
     Fmt.result ppf
-      ~ok:(Fmt.pair ~sep:(Fmt.any ",") Fmt.int Fmt.int)
-      ~error:Inf.Ns.pp_error
-  in
-  let equal =
-    Result.equal
-      ~ok:
-        (fun (i1, o1) (i2, o2) -> Int.equal i1 i2 && Int.equal o1 o2)
-      ~error:
-        (fun e1 e2 -> e1 == e2)
-  in
+      ~ok:(Fmt.pair ~sep:Fmt.comma Fmt.int Fmt.int)
+      ~error:Inf.Ns.pp_error in
+  let equal r1 r2 =
+    match r1, r2 with
+    | Ok (i1, o1), Ok (i2, o2) -> Int.equal i1 i2 && Int.equal o1 o2
+    | Error e1, Error e2 -> e1 == e2
+    | _ -> false in
   Alcotest.testable pp equal
 
 let decode_i =

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -635,9 +635,10 @@ let fuzz2 () =
       (* ~~~~~~~~:,P *)
     ] in
   let expected = String.concat "" expected in
+  (* All of src is not used (last byte is useless) *)
   Alcotest.(check check_decode)
     "fuzz2"
-    (Ok (De.bigstring_length src, String.length expected))
+    (Ok (De.bigstring_length src - 1, String.length expected))
     res
   ; Alcotest.(check string)
       "fuzz2" expected
@@ -690,9 +691,10 @@ let fuzz3 () =
       (* .v.v.v.v.v.v.v.v *); "\xc8\x76\xc8\x76" (* .v.v *)
     ] in
   let expected = String.concat "" expected in
+  (* All of src is not used (last byte is useless) *)
   Alcotest.(check check_decode)
     "fuzz3"
-    (Ok (De.bigstring_length src, String.length expected))
+    (Ok (De.bigstring_length src - 2, String.length expected))
     res
   ; Alcotest.(check string)
       "fuzz3" expected
@@ -713,9 +715,10 @@ let fuzz4 () =
       (* ~..~..~..~..~..~ *); "\xc8\x76\x75\x75\x75\x75\x75\x75" (* .vuuuuuu *)
     ] in
   let expected = String.concat "" expected in
+  (* All of src is not used (last byte is useless) *)
   Alcotest.(check check_decode)
     "fuzz4"
-    (Ok (De.bigstring_length src, String.length expected))
+    (Ok (De.bigstring_length src - 1, String.length expected))
     res
   ; Alcotest.(check string)
       "fuzz4" expected
@@ -737,9 +740,10 @@ let fuzz5 () =
       (* PPPPPPPPP *)
     ] in
   let expected = String.concat "" expected in
+  (* All of src is not used (last byte is useless) *)
   Alcotest.(check check_decode)
     "fuzz5"
-    (Ok (De.bigstring_length src, String.length expected))
+    (Ok (De.bigstring_length src - 1, String.length expected))
     res
   ; Alcotest.(check string)
       "fuzz5" expected
@@ -756,9 +760,10 @@ let fuzz6 () =
       (* .YYY^.Y^.Y^.Y^.Y *); "\x5e\xe3\x33" (* ^.3 *)
     ] in
   let expected = String.concat "" expected in
+  (* All of src is not used (last 2 bytes are useless) *)
   Alcotest.(check check_decode)
     "fuzz6"
-    (Ok (De.bigstring_length src, String.length expected))
+    (Ok (De.bigstring_length src - 2, String.length expected))
     res
   ; Alcotest.(check string)
       "fuzz6" expected
@@ -770,9 +775,10 @@ let fuzz7 () =
     bigstring_of_string "\x93\x3a\x55\x69\x12\x3a\x3f\x10\x08\x01\x00\x00" in
   let res = Inf.Ns.inflate src dst in
   let expected = "\x1a\xca\x79\x34\x55\x9f\x51\x9f\x51\x9f" in
+  (* All of src is not used (last 2 bytes is useless) *)
   Alcotest.(check check_decode)
     "fuzz7"
-    (Ok (De.bigstring_length src, String.length expected))
+    (Ok (De.bigstring_length src - 2, String.length expected))
     res
   ; Alcotest.(check string)
       "fuzz7" expected
@@ -975,7 +981,8 @@ let fuzz15 () =
   let res = Inf.Ns.inflate src dst in
   let expected = ["\x78\x20\x5f\x74\x6c\x69\x63" (* x _tlic *)] in
   let expected = String.concat "" expected in
-  Alcotest.(check check_decode) "fuzz15" (Ok (40, String.length expected)) res
+  (* All of src is not used (last byte is useless) *)
+  Alcotest.(check check_decode) "fuzz15" (Ok (39, String.length expected)) res
   ; Alcotest.(check string)
       "fuzz15" expected
       (Bigstringaf.substring dst ~off:0 ~len:(check_decode_o res))
@@ -1047,7 +1054,8 @@ let fuzz18 () =
       (* gn` gnc)gn` gs`i *); "\x63" (* c *)
     ] in
   let expected = String.concat "" expected in
-  Alcotest.(check check_decode) "fuzz18" (Ok (60, String.length expected)) res
+  (* All of src is not used (last byte is useless) *)
+  Alcotest.(check check_decode) "fuzz18" (Ok (59, String.length expected)) res
   ; Alcotest.(check string)
       "fuzz18" expected
       (Bigstringaf.substring dst ~off:0 ~len:(check_decode_o res))
@@ -1071,9 +1079,8 @@ let compress_and_uncompress ic =
     ; let dst_def = bigstring_create (Def.Ns.compress_bound in_len) in
       match Def.Ns.deflate src_def dst_def with
       | Ok len -> (
-        let src_inf = Bigstringaf.sub dst_def ~off:0 ~len in
         let dst_inf = bigstring_create in_len in
-        match Inf.Ns.inflate src_inf dst_inf with
+        match Inf.Ns.inflate dst_def dst_inf with
         | Ok (i_len, o_len) ->
           Alcotest.(check int) "inflate same len" len i_len
           ; Alcotest.(check int) "keep good length" in_len o_len
@@ -1113,9 +1120,8 @@ let zlib_compress_and_uncompress ic =
     ; let dst_def = bigstring_create (Zl.Def.Ns.compress_bound in_len) in
       match Zl.Def.Ns.deflate src_def dst_def with
       | Ok len -> (
-        let src_inf = Bigstringaf.sub dst_def ~off:0 ~len in
         let dst_inf = bigstring_create in_len in
-        match Zl.Inf.Ns.inflate src_inf dst_inf with
+        match Zl.Inf.Ns.inflate dst_def dst_inf with
         | Ok (i_len, o_len) ->
           Alcotest.(check int) "inflate same len" len i_len
           ; Alcotest.(check int) "keep good length" in_len o_len

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -135,7 +135,7 @@ let invalid_complement_of_length () =
   Alcotest.(check decode)
     "invalid complement of length"
     (Error `Invalid_complement_of_length)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let invalid_kind_of_block () =
   Alcotest.test_case "invalid kind of block" `Quick @@ fun () ->
@@ -143,7 +143,7 @@ let invalid_kind_of_block () =
   Alcotest.(check decode)
     "invalid kind of block"
     (Error `Invalid_kind_of_block)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let invalid_code_lengths () =
   Alcotest.test_case "invalid code lengths" `Quick @@ fun () ->
@@ -151,7 +151,7 @@ let invalid_code_lengths () =
   Alcotest.(check decode)
     "invalid code lengths"
     (Error `Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let invalid_bit_length_repeat () =
   Alcotest.test_case "invalid bit length repeat" `Quick @@ fun () ->
@@ -159,7 +159,7 @@ let invalid_bit_length_repeat () =
   Alcotest.(check decode)
     "invalid bit length repeat"
     (Error `Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let invalid_codes () =
   Alcotest.test_case "invalid codes -- missing end-of-block" `Quick @@ fun () ->
@@ -167,7 +167,7 @@ let invalid_codes () =
   Alcotest.(check decode)
     "invalid codes -- missing end-of-block"
     (Error `Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let invalid_lengths () =
   Alcotest.test_case "invalid literals/lengths" `Quick @@ fun () ->
@@ -178,7 +178,7 @@ let invalid_lengths () =
   Alcotest.(check decode)
     "invalid literals/lengths"
     (Error `Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let invalid_distances () =
   Alcotest.test_case "invalid distances" `Quick @@ fun () ->
@@ -188,7 +188,7 @@ let invalid_distances () =
   Alcotest.(check decode)
     "invalid distances"
     (Error `Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let too_many_length_or_distance_symbols () =
   Alcotest.test_case "too many length of distance symbols" `Quick @@ fun () ->
@@ -196,7 +196,7 @@ let too_many_length_or_distance_symbols () =
   Alcotest.(check decode)
     "too many length of distance symbols"
     (Error `Unexpected_end_of_input)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 (* XXX(dinosaure): error is not conform to what we expect (best will be [Invalid
    dictionary]), TODO! *)
@@ -207,7 +207,7 @@ let invalid_distance_code () =
   Alcotest.(check decode)
     "invalid distance code"
     (Error `Invalid_distance_code)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 (* XXX(dinosaure): see [Inf.base_dist]'s comment about this behavior. *)
 
@@ -219,12 +219,12 @@ let invalid_distance_too_far_back () =
   Alcotest.(check decode)
     "invalid distance too far back"
     (Error `Invalid_distance)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let fixed () =
   Alcotest.test_case "fixed" `Quick @@ fun () ->
   let src = bigstring_of_string "\x03\x00" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "" in
   Alcotest.(check decode)
     "fixed"
@@ -237,7 +237,7 @@ let fixed () =
 let stored () =
   Alcotest.test_case "stored" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x01\x00\xfe\xff\x00" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "\x00" in
   Alcotest.(check decode)
     "stored"
@@ -252,7 +252,7 @@ let length_extra () =
   let src =
     bigstring_of_string
       "\xed\xc0\x01\x01\x00\x00\x00\x40\x20\xff\x57\x1b\x42\x2c\x4f" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = String.make 516 '\x00' in
   Alcotest.(check decode)
     "length extra"
@@ -268,7 +268,7 @@ let long_distance_and_extra () =
     bigstring_of_string
       "\xed\xcf\xc1\xb1\x2c\x47\x10\xc4\x30\xfa\x6f\x35\x1d\x01\x82\x59\x3d\xfb\xbe\x2e\x2a\xfc\x0f\x0c"
   in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = String.make 518 '\x00' in
   Alcotest.(check decode)
     "long distance and extra"
@@ -284,7 +284,7 @@ let window_end () =
     bigstring_of_string
       "\xed\xc0\x81\x00\x00\x00\x00\x80\xa0\xfd\xa9\x17\xa9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06"
   in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = String.make 33025 '\x00' in
   Alcotest.(check decode)
     "window end"
@@ -297,7 +297,7 @@ let window_end () =
 let flat_of_string () =
   Alcotest.test_case "flat of string" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x00\x00\xff\xff" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "" in
   Alcotest.(check decode)
     "flat of string"
@@ -310,7 +310,7 @@ let flat_of_string () =
 let flat_block () =
   Alcotest.test_case "flat block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "\xde\xad\xbe\xef" in
   Alcotest.(check decode)
     "flat block"
@@ -341,7 +341,7 @@ let huffman_length_extra () =
         "encoding" res "\237\193\001\001\000\000\000@ \255W\027B\193\234\004"
 
       ; let src = bigstring_of_string res in
-        let res = Inf.Ns.inflate ~src ~dst in
+        let res = Inf.Ns.inflate src dst in
         let expected = String.make (258 + 256 + 2) '\000' in
         Alcotest.(check decode)
           "huffman length extra"
@@ -383,7 +383,7 @@ let dynamic_and_fixed () =
       ; `Block {Def.kind= Def.Fixed; Def.last= true}; `Flush
       ]
     ; let src = bigstring_of_string (Buffer.contents res) in
-      let res = Inf.Ns.inflate ~src ~dst in
+      let res = Inf.Ns.inflate src dst in
       let expected = "aaaabbbb" in
       Alcotest.(check decode)
         "dynamic+fixed"
@@ -423,7 +423,7 @@ let fixed_and_dynamic () =
       ]
     ; Fmt.epr "> %S.\n%!" (Buffer.contents res)
     ; let src = bigstring_of_string (Buffer.contents res) in
-      let res = Inf.Ns.inflate ~src ~dst in
+      let res = Inf.Ns.inflate src dst in
       let expected = "aaaabbbb" in
       Alcotest.(check decode)
         "fixed+dynamic"
@@ -473,7 +473,7 @@ let dynamic_and_dynamic () =
 
       ; Fmt.epr "> %S.\n%!" (Buffer.contents res)
       ; let src = bigstring_of_string (Buffer.contents res) in
-        let res = Inf.Ns.inflate ~src ~dst in
+        let res = Inf.Ns.inflate src dst in
         let expected = "aaaabbbb" in
         Alcotest.(check decode)
           "dynamic+dynamic"
@@ -492,7 +492,7 @@ let max_flat () =
   ; Bytes.set inputs 2 '\xff'
   ; (* len *)
     let src = bigstring_of_string (Bytes.unsafe_to_string inputs) in
-    let res = Inf.Ns.inflate ~src ~dst in
+    let res = Inf.Ns.inflate src dst in
     let expected = String.make 0xffff '\x00' in
     Alcotest.(check decode)
       "biggest flat block"
@@ -518,7 +518,7 @@ let flat () =
   Alcotest.(check string)
     "deadbeef deflated" "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" res0
   ; let src = bigstring_of_string res0 in
-    let res = Inf.Ns.inflate ~src ~dst in
+    let res = Inf.Ns.inflate src dst in
     let expected = "\xde\xad\xbe\xef" in
     Alcotest.(check decode)
       "encode flat"
@@ -548,7 +548,7 @@ let fixed_and_flat () =
            (`Block {Def.kind= Def.Flat (Queue.length q); last= true})) in
   let res0 = go (Def.encode encoder `Flush) in
   let src = bigstring_of_string res0 in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "aaaa\xde\xad\xbe\xef" in
   Alcotest.(check decode)
     "fixed+flat"
@@ -578,7 +578,7 @@ let flat_and_fixed () =
     go (Def.encode encoder (`Block {Def.kind= Def.Flat 4; last= false})) in
 
   let src = bigstring_of_string res0 in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "\xde\xad\xbe\xefaaaa" in
   Alcotest.(check decode)
     "flat+fixed"
@@ -596,7 +596,7 @@ let fuzz0 () =
       \ \
        s\017\027\211\\\006\211w\176`\142\2007\156oZBo\163\136\017\247\158\247\012e\241\234sn_$\210\223\017\213\138\147]\129M\137<\242\1867\021c\194\156\135\194\167-wo\006\200\198"
   in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "\xe3\x85" in
   Alcotest.(check decode) "fuzz0" (Ok (4, String.length expected)) res
   ; Alcotest.(check string)
@@ -606,7 +606,7 @@ let fuzz0 () =
 let fuzz1 () =
   Alcotest.test_case "fuzz1" `Quick @@ fun () ->
   let src = bigstring_of_string "\019\208nO\200\189r\020\176" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "\016+\135`m\212\197" in
   Alcotest.(check decode)
     "fuzz1"
@@ -620,7 +620,7 @@ let fuzz2 () =
   Alcotest.test_case "fuzz2" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x3a\x55\x47\x12\x80\x51\x56\x3a\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\x1a\xca\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e"
@@ -644,7 +644,7 @@ let fuzz3 () =
   Alcotest.test_case "fuzz3" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x36\x0a\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a"
@@ -699,7 +699,7 @@ let fuzz4 () =
   Alcotest.test_case "fuzz4" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x56\x0a\x06\x80\x00" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a"
@@ -726,7 +726,7 @@ let fuzz5 () =
       (* .:U............. *); "\x01\x01\x01\x01\x01\x00\x00" (* ....... *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\x1a\xca\x78\x78\x78\x78\x78\x78\x78\x50\x50\x37\x50\x50\x50\x50"
@@ -746,7 +746,7 @@ let fuzz6 () =
   Alcotest.test_case "fuzz6" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x8c\x8c\x8c\x8c\x7b\x8c\x8c\x8c\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\x19\x59\x59\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59"
@@ -765,7 +765,7 @@ let fuzz7 () =
   Alcotest.test_case "fuzz7" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x3a\x55\x69\x12\x3a\x3f\x10\x08\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "\x1a\xca\x79\x34\x55\x9f\x51\x9f\x51\x9f" in
   Alcotest.(check decode)
     "fuzz7"
@@ -781,7 +781,7 @@ let fuzz8 () =
   Alcotest.(check decode)
     "fuzz8"
     (Error `Unexpected_end_of_input)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let fuzz9 () =
   Alcotest.test_case "fuzz9" `Quick @@ fun () ->
@@ -797,7 +797,7 @@ let fuzz9 () =
   Alcotest.(check decode)
     "fuzz9"
     (Error `Invalid_distance)
-    (Inf.Ns.inflate ~src ~dst)
+    (Inf.Ns.inflate src dst)
 
 let fuzz10 () =
   Alcotest.test_case "fuzz10" `Quick @@ fun () ->
@@ -807,7 +807,7 @@ let fuzz10 () =
     ; `Copy (1, 19); `End
     ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   Alcotest.(check decode) "fuzz10" (Ok (De.bigstring_length src, 22)) res
 
 let fuzz11 () =
@@ -816,7 +816,7 @@ let fuzz11 () =
     [`Literal (Char.chr 228); `Literal (Char.chr 255); `Copy (1, 130); `End]
   in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "\228" ^ String.make 131 '\xff' in
   Alcotest.(check decode)
     "fuzz11"
@@ -834,7 +834,7 @@ let fuzz12 () =
     ; `Copy (2, 249); `End
     ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\x47\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
@@ -882,7 +882,7 @@ let fuzz13 () =
   Alcotest.test_case "fuzz13" `Quick @@ fun () ->
   let src = ["\x9b\x0e\x02\x00" (* .... *)] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = "\x97\x97\x97\x97\x97" in
   Alcotest.(check decode)
     "fuzz13"
@@ -902,7 +902,7 @@ let fuzz14 () =
       (*  ..........d.... *); "\x8f\xcd\x0e\x02\x21\xff\xff\x80" (* ....!... *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\x57\xff\xc6\xff\xc6\xff\xc6\xff\xc6\x9b\x52\xc6\x9b\x52\xc6\xc6"
@@ -969,7 +969,7 @@ let fuzz15 () =
       (* ..]f..WW..[..s *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = ["\x78\x20\x5f\x74\x6c\x69\x63" (* x _tlic *)] in
   let expected = String.concat "" expected in
   Alcotest.(check decode) "fuzz15" (Ok (40, String.length expected)) res
@@ -985,7 +985,7 @@ let fuzz16 () =
     ; `Copy (527, 208); `Copy (129, 258); `End
     ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected = String.make 1068 '@' in
   Alcotest.(check decode)
     "fuzz16"
@@ -1003,7 +1003,7 @@ let fuzz17 () =
     ; `Literal (Char.chr 218); `Literal (Char.chr 0); `End
     ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda"
@@ -1033,7 +1033,7 @@ let fuzz18 () =
       (* ..LV..WW..[..`.. *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst in
+  let res = Inf.Ns.inflate src dst in
   let expected =
     [
       "\x75\x27\x5a\xfb\x64\x64\x2b\x63\x29\x67\x6e\x60\x20\x67\x6e\x60"
@@ -1066,10 +1066,10 @@ let compress_and_uncompress ic =
       unsafe_set_uint8 src_def i v
     done
     ; let dst_def = bigstring_create (Def.Ns.compress_bound in_len) in
-      let len = Def.Ns.deflate ~level:1 ~src:src_def ~dst:dst_def in
+      let len = Def.Ns.deflate ~level:1 src_def dst_def in
       let src_inf = Bigstringaf.sub dst_def ~off:0 ~len in
       let dst_inf = bigstring_create in_len in
-      match Inf.Ns.inflate ~src:src_inf ~dst:dst_inf with
+      match Inf.Ns.inflate src_inf dst_inf with
       | Ok (i_len, o_len) ->
         Alcotest.(check int) "inflate same len" len i_len
         ; Alcotest.(check int) "keep good length" in_len o_len
@@ -1105,10 +1105,10 @@ let zlib_compress_and_uncompress ic =
       unsafe_set_uint8 src_def i v
     done
     ; let dst_def = bigstring_create (Zl.Def.Ns.compress_bound in_len) in
-      let len = Zl.Def.Ns.deflate ~level:1 ~src:src_def ~dst:dst_def in
+      let len = Zl.Def.Ns.deflate src_def dst_def in
       let src_inf = Bigstringaf.sub dst_def ~off:0 ~len in
       let dst_inf = bigstring_create in_len in
-      match Zl.Inf.Ns.inflate ~src:src_inf ~dst:dst_inf with
+      match Zl.Inf.Ns.inflate src_inf dst_inf with
       | Ok (i_len, o_len) ->
         Alcotest.(check int) "inflate same len" len i_len
         ; Alcotest.(check int) "keep good length" in_len o_len
@@ -1148,7 +1148,7 @@ let test_corpus_with_zlib filename =
 let encoder_0 () =
   Alcotest.test_case "encoder 0" `Quick @@ fun () ->
   let src = bigstring_of_string "\x00" in
-  let res = Def.Ns.deflate ~level:0 ~src ~dst in
+  let res = Def.Ns.deflate ~level:0 src dst in
   let expected = "\x01\x01\x00\xfe\xff\x00" in
   Alcotest.(check int) "encoder 0" (String.length expected) res
   ; ( Bigstringaf.to_string dst |> fun s ->
@@ -1169,7 +1169,7 @@ let encoder_1 () =
       (* ................ *); "\x00\x00\x00\x00\x00\x00\x00\x00" (* ........ *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Def.Ns.deflate ~level:1 ~src ~dst in
+  let res = Def.Ns.deflate ~level:1 src dst in
   let expected = "\x63\x20\x13\x00\x00" in
   Alcotest.(check int) "encoder 1" (String.length expected) res
   ; ( Bigstringaf.to_string dst |> fun s ->

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -1054,7 +1054,7 @@ let compress_and_uncompress ic =
     done
     ; let dst_def =
         bigstring_create (Def.Ns.compress_bound (in_channel_length ic)) in
-      let len = Def.Ns.deflate (Def.Ns.encoder 1) ~src:src_def ~dst:dst_def in
+      let len = Def.Ns.deflate ~level:1 ~src:src_def ~dst:dst_def in
       let oc = open_out "compress" in
       output_bytes oc
         (Bigstringaf.substring ~off:0 ~len dst_def |> Bytes.of_string)
@@ -1092,9 +1092,8 @@ let test_corpus filename =
 
 let encoder_0 () =
   Alcotest.test_case "encoder 0" `Quick @@ fun () ->
-  let encoder = Def.Ns.encoder 0 in
   let src = bigstring_of_string "\x00" in
-  let res = Def.Ns.deflate encoder ~src ~dst in
+  let res = Def.Ns.deflate ~level:0 ~src ~dst in
   let expected = "\x01\x01\x00\xfe\xff\x00" in
   Alcotest.(check int) "encoder 0" (String.length expected) res
   ; ( Bigstringaf.to_string dst |> fun s ->
@@ -1105,7 +1104,6 @@ let encoder_0 () =
 
 let encoder_1 () =
   Alcotest.test_case "encoder 1" `Quick @@ fun () ->
-  let encoder = Def.Ns.encoder 1 in
   let src =
     [
       "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
@@ -1116,7 +1114,7 @@ let encoder_1 () =
       (* ................ *); "\x00\x00\x00\x00\x00\x00\x00\x00" (* ........ *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Def.Ns.deflate encoder ~src ~dst in
+  let res = Def.Ns.deflate ~level:1 ~src ~dst in
   let expected = "\x63\x20\x13\x00\x00" in
   Alcotest.(check int) "encoder 1" (String.length expected) res
   ; ( Bigstringaf.to_string dst |> fun s ->
@@ -1126,89 +1124,40 @@ let encoder_1 () =
       "0x00" expected
       (Bigstringaf.substring dst ~off:0 ~len:res)
 
-let encoder_2 () =
-  Alcotest.test_case "encoder 2" `Quick @@ fun () ->
-  let _encoder = Def.Ns.encoder 2 in
-  ()
-
-let encoder_3 () =
-  Alcotest.test_case "encoder 3" `Quick @@ fun () ->
-  let _encoder = Def.Ns.encoder 3 in
-  ()
-
-let encoder_4 () =
-  Alcotest.test_case "encoder 4" `Quick @@ fun () ->
-  let _encoder = Def.Ns.encoder 4 in
-  ()
-
-let encoder_5 () =
-  Alcotest.test_case "encoder 5" `Quick @@ fun () ->
-  let _encoder = Def.Ns.encoder 5 in
-  ()
-
-let encoder_6 () =
-  Alcotest.test_case "encoder 6" `Quick @@ fun () ->
-  let _encoder = Def.Ns.encoder 6 in
-  ()
-
-let encoder_7 () =
-  Alcotest.test_case "encoder 7" `Quick @@ fun () ->
-  let _encoder = Def.Ns.encoder 7 in
-  ()
-
-let encoder_8 () =
-  Alcotest.test_case "encoder 8" `Quick @@ fun () ->
-  let _encoder = Def.Ns.encoder 8 in
-  ()
-
-let encoder_9 () =
-  Alcotest.test_case "encoder 9" `Quick @@ fun () ->
-  let _encoder = Def.Ns.encoder 9 in
-  ()
-
 let tests =
   [
-    (* "ns_encoder"
+    "ns_encoder"
        , [ encoder_0 ()
-         ; encoder_1 ()
-         ; encoder_2 ()
-         ; encoder_3 ()
-         ; encoder_4 ()
-         ; encoder_5 ()
-         ; encoder_6 ()
-         ; encoder_7 ()
-         ; encoder_8 ()
-         ; encoder_9 () ]
-         [
-         ( "ns_invalids"
+         ; encoder_1 () ];
+         "ns_invalids"
          , [
              invalid_complement_of_length (); invalid_kind_of_block ()
            ; invalid_code_lengths (); invalid_bit_length_repeat (); invalid_codes ()
            ; invalid_lengths (); invalid_distances ()
            ; too_many_length_or_distance_symbols (); invalid_distance_code ()
            ; invalid_distance_too_far_back ()
-           ] )
-       ; ( "ns_valids"
+           ]
+       ; "ns_valids"
          , [
              fixed (); stored (); length_extra (); long_distance_and_extra ()
            ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
            ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
            ; flat_block (); flat (); max_flat (); fixed_and_flat ()
            ; flat_and_fixed ()
-           ] )
-       ; ( "ns_fuzz"
+           ]
+       ; "ns_fuzz"
          , [
              fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
            ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 (); fuzz13 ()
            ; fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
-           ] )
-       ; *)
-    ( "ns_calgary"
+           ]
+       ;
+    "ns_calgary"
     , [
         test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
       ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
       ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
       ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
       ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
-      ] )
+      ]
   ]

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -1047,77 +1047,163 @@ let b = Buffer.create 4096
 let compress_and_uncompress ic =
   Buffer.clear b
   ; Queue.reset q
-  ; let refill input =
-      let len = min (in_channel_length ic - pos_in ic) io_buffer_size in
-      for i = 0 to len - 1 do
-        let v = Char.code (input_char ic) in
-        unsafe_set_uint8 input i v
-      done
-      ; len in
-    let flush output l =
-      for i = 0 to l - 1 do
-        Buffer.add_char b (Char.unsafe_chr (unsafe_get_uint8 output i))
-      done in
-
-    Higher.compress ~w:w0 ~q ~refill ~flush i o
-
-    ; let src = bigstring_of_string (Bytes.to_string (Buffer.to_bytes b)) in
-      let dst = bigstring_create (in_channel_length ic) in
-
-      match Inf.Ns.inflate ~src ~dst ~w:w1 with
-      | Ok (_, l) ->
-        Stdlib.seek_in ic 0
-        ; Buffer.clear b
-        ; for i = 0 to l - 1 do
-            Buffer.add_char b (Char.unsafe_chr (unsafe_get_uint8 dst i))
-          done
-        ; let contents = Buffer.contents b in
-          let rec slow_compare pos =
-            match input_char ic with
-            | chr ->
-              if pos >= String.length contents then
-                Fmt.invalid_arg "Reach end of contents"
-              ; if contents.[pos] <> chr then
-                  Fmt.invalid_arg "Contents differ at %08x\n%!" pos
-              ; slow_compare (succ pos)
-            | exception End_of_file ->
-              if pos <> String.length contents then
-                Fmt.invalid_arg "Lengths differ: (contents: %d, file: %d)"
-                  (String.length contents) pos in
-          slow_compare 0
-      | Error err ->
-        Alcotest.failf "Error when inflating: %a" Inf.Ns.pp_error err
+  ; let src_def = bigstring_create (in_channel_length ic) in
+    for i = 0 to in_channel_length ic - 1 do
+      let v = Char.code (input_char ic) in
+      unsafe_set_uint8 src_def i v
+    done
+    ; let dst_def =
+        bigstring_create (Def.Ns.compress_bound (in_channel_length ic)) in
+      let len = Def.Ns.deflate (Def.Ns.encoder 1) ~src:src_def ~dst:dst_def in
+      let oc = open_out "compress" in
+      output_bytes oc
+        (Bigstringaf.substring ~off:0 ~len dst_def |> Bytes.of_string)
+      ; (* ignore (assert false); *)
+        let src_inf = Bigstringaf.sub dst_def ~off:0 ~len in
+        let dst_inf = bigstring_create (in_channel_length ic) in
+        match Inf.Ns.inflate ~src:src_inf ~dst:dst_inf ~w:w1 with
+        | Ok (_, len) ->
+          Stdlib.seek_in ic 0
+          ; Buffer.clear b
+          ; for i = 0 to len - 1 do
+              Buffer.add_char b (Char.unsafe_chr (unsafe_get_uint8 dst_inf i))
+            done
+          ; let contents = Buffer.contents b in
+            let rec slow_compare pos =
+              match input_char ic with
+              | chr ->
+                if pos >= String.length contents then
+                  Fmt.invalid_arg "Reach end of contents"
+                ; if contents.[pos] <> chr then
+                    Fmt.invalid_arg "Contents differ at %08x\n%!" pos
+                ; slow_compare (succ pos)
+              | exception End_of_file ->
+                if pos <> String.length contents then
+                  Fmt.invalid_arg "Lengths differ: (contents: %d, file: %d)"
+                    (String.length contents) pos in
+            slow_compare 0
+        | Error err ->
+          Alcotest.failf "Error when inflating: %a" Inf.Ns.pp_error err
 
 let test_corpus filename =
   Alcotest.test_case filename `Slow @@ fun () ->
   let ic = open_in Filename.(concat "corpus" filename) in
   compress_and_uncompress ic ; close_in ic
 
+let encoder_0 () =
+  Alcotest.test_case "encoder 0" `Quick @@ fun () ->
+  let encoder = Def.Ns.encoder 0 in
+  let src = bigstring_of_string "\x00" in
+  let res = Def.Ns.deflate encoder ~src ~dst in
+  let expected = "\x01\x01\x00\xfe\xff\x00" in
+  Alcotest.(check int) "encoder 0" (String.length expected) res
+  ; ( Bigstringaf.to_string dst |> fun s ->
+      String.sub s 0 res |> String.iteri (fun i -> Fmt.pr "%d: %C\n%!" i) )
+  ; Alcotest.(check string)
+      "0x00" expected
+      (Bigstringaf.substring dst ~off:0 ~len:res)
+
+let encoder_1 () =
+  Alcotest.test_case "encoder 1" `Quick @@ fun () ->
+  let encoder = Def.Ns.encoder 1 in
+  let src =
+    [
+      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+      (* ................ *)
+    ; "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+      (* ................ *)
+    ; "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+      (* ................ *); "\x00\x00\x00\x00\x00\x00\x00\x00" (* ........ *)
+    ] in
+  let src = bigstring_of_string (String.concat "" src) in
+  let res = Def.Ns.deflate encoder ~src ~dst in
+  let expected = "\x63\x20\x13\x00\x00" in
+  Alcotest.(check int) "encoder 1" (String.length expected) res
+  ; ( Bigstringaf.to_string dst |> fun s ->
+      String.sub s 0 res
+      |> String.iteri (fun i j -> Fmt.pr "%d: \\x%02x\n%!" i (Char.code j)) )
+  ; Alcotest.(check string)
+      "0x00" expected
+      (Bigstringaf.substring dst ~off:0 ~len:res)
+
+let encoder_2 () =
+  Alcotest.test_case "encoder 2" `Quick @@ fun () ->
+  let _encoder = Def.Ns.encoder 2 in
+  ()
+
+let encoder_3 () =
+  Alcotest.test_case "encoder 3" `Quick @@ fun () ->
+  let _encoder = Def.Ns.encoder 3 in
+  ()
+
+let encoder_4 () =
+  Alcotest.test_case "encoder 4" `Quick @@ fun () ->
+  let _encoder = Def.Ns.encoder 4 in
+  ()
+
+let encoder_5 () =
+  Alcotest.test_case "encoder 5" `Quick @@ fun () ->
+  let _encoder = Def.Ns.encoder 5 in
+  ()
+
+let encoder_6 () =
+  Alcotest.test_case "encoder 6" `Quick @@ fun () ->
+  let _encoder = Def.Ns.encoder 6 in
+  ()
+
+let encoder_7 () =
+  Alcotest.test_case "encoder 7" `Quick @@ fun () ->
+  let _encoder = Def.Ns.encoder 7 in
+  ()
+
+let encoder_8 () =
+  Alcotest.test_case "encoder 8" `Quick @@ fun () ->
+  let _encoder = Def.Ns.encoder 8 in
+  ()
+
+let encoder_9 () =
+  Alcotest.test_case "encoder 9" `Quick @@ fun () ->
+  let _encoder = Def.Ns.encoder 9 in
+  ()
+
 let tests =
   [
-    ( "ns_invalids"
-    , [
-        invalid_complement_of_length (); invalid_kind_of_block ()
-      ; invalid_code_lengths (); invalid_bit_length_repeat (); invalid_codes ()
-      ; invalid_lengths (); invalid_distances ()
-      ; too_many_length_or_distance_symbols (); invalid_distance_code ()
-      ; invalid_distance_too_far_back ()
-      ] )
-  ; ( "ns_valids"
-    , [
-        fixed (); stored (); length_extra (); long_distance_and_extra ()
-      ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
-      ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
-      ; flat_block (); flat (); max_flat (); fixed_and_flat ()
-      ; flat_and_fixed ()
-      ] )
-  ; ( "ns_fuzz"
-    , [
-        fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
-      ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 (); fuzz13 ()
-      ; fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
-      ] )
-  ; ( "ns_calgary"
+    (* "ns_encoder"
+       , [ encoder_0 ()
+         ; encoder_1 ()
+         ; encoder_2 ()
+         ; encoder_3 ()
+         ; encoder_4 ()
+         ; encoder_5 ()
+         ; encoder_6 ()
+         ; encoder_7 ()
+         ; encoder_8 ()
+         ; encoder_9 () ]
+         [
+         ( "ns_invalids"
+         , [
+             invalid_complement_of_length (); invalid_kind_of_block ()
+           ; invalid_code_lengths (); invalid_bit_length_repeat (); invalid_codes ()
+           ; invalid_lengths (); invalid_distances ()
+           ; too_many_length_or_distance_symbols (); invalid_distance_code ()
+           ; invalid_distance_too_far_back ()
+           ] )
+       ; ( "ns_valids"
+         , [
+             fixed (); stored (); length_extra (); long_distance_and_extra ()
+           ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
+           ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
+           ; flat_block (); flat (); max_flat (); fixed_and_flat ()
+           ; flat_and_fixed ()
+           ] )
+       ; ( "ns_fuzz"
+         , [
+             fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
+           ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 (); fuzz13 ()
+           ; fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
+           ] )
+       ; *)
+    ( "ns_calgary"
     , [
         test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
       ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -1126,38 +1126,35 @@ let encoder_1 () =
 
 let tests =
   [
-    "ns_encoder"
-       , [ encoder_0 ()
-         ; encoder_1 () ];
-         "ns_invalids"
-         , [
-             invalid_complement_of_length (); invalid_kind_of_block ()
-           ; invalid_code_lengths (); invalid_bit_length_repeat (); invalid_codes ()
-           ; invalid_lengths (); invalid_distances ()
-           ; too_many_length_or_distance_symbols (); invalid_distance_code ()
-           ; invalid_distance_too_far_back ()
-           ]
-       ; "ns_valids"
-         , [
-             fixed (); stored (); length_extra (); long_distance_and_extra ()
-           ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
-           ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
-           ; flat_block (); flat (); max_flat (); fixed_and_flat ()
-           ; flat_and_fixed ()
-           ]
-       ; "ns_fuzz"
-         , [
-             fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
-           ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 (); fuzz13 ()
-           ; fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
-           ]
-       ;
-    "ns_calgary"
+    "ns_encoder", [encoder_0 (); encoder_1 ()]
+  ; ( "ns_invalids"
+    , [
+        invalid_complement_of_length (); invalid_kind_of_block ()
+      ; invalid_code_lengths (); invalid_bit_length_repeat (); invalid_codes ()
+      ; invalid_lengths (); invalid_distances ()
+      ; too_many_length_or_distance_symbols (); invalid_distance_code ()
+      ; invalid_distance_too_far_back ()
+      ] )
+  ; ( "ns_valids"
+    , [
+        fixed (); stored (); length_extra (); long_distance_and_extra ()
+      ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
+      ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
+      ; flat_block (); flat (); max_flat (); fixed_and_flat ()
+      ; flat_and_fixed ()
+      ] )
+  ; ( "ns_fuzz"
+    , [
+        fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
+      ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 (); fuzz13 ()
+      ; fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
+      ] )
+  ; ( "ns_calgary"
     , [
         test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
       ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
       ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
       ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
       ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
-      ]
+      ] )
   ]

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -3,23 +3,30 @@ let seed = "kle6/0eMVRsY+AlbHjLTMQ=="
 let () =
   let raw = Base64.decode_exn seed in
   let res = Array.make 8 0 in
-  for i = 0 to 7 do res.(i) <- (Char.code raw.[i] lsl 8) lor (Char.code raw.[i + 1]) done ;
-  Random.full_init res
+  for i = 0 to 7 do
+    res.(i) <- (Char.code raw.[i] lsl 8) lor Char.code raw.[i + 1]
+  done
+  ; Random.full_init res
 
 let random len =
   let res = Bytes.create len in
-  for i = 0 to len - 1 do Bytes.set res i (Char.chr (Random.int 256)) done ;
-  Bytes.unsafe_to_string res
+  for i = 0 to len - 1 do
+    Bytes.set res i (Char.chr (Random.int 256))
+  done
+  ; Bytes.unsafe_to_string res
 
 open De (* au detail *)
 
-external string_unsafe_get_uint32 : string -> int -> int32 = "%caml_string_get32"
+external string_unsafe_get_uint32 : string -> int -> int32
+  = "%caml_string_get32"
 
 let string_unsafe_get_uint8 : string -> int -> int =
-  fun buf off -> Char.code (String.get buf off)
+ fun buf off -> Char.code buf.[off]
 
-external unsafe_set_uint8  : bigstring -> int -> int -> unit = "%caml_ba_set_1"
-external unsafe_set_uint32 : bigstring -> int -> int32 -> unit = "%caml_bigstring_set32"
+external unsafe_set_uint8 : bigstring -> int -> int -> unit = "%caml_ba_set_1"
+
+external unsafe_set_uint32 : bigstring -> int -> int32 -> unit
+  = "%caml_bigstring_set32"
 
 let bigstring_of_string v =
   let len = String.length v in
@@ -27,58 +34,57 @@ let bigstring_of_string v =
   let len0 = len land 3 in
   let len1 = len asr 2 in
 
-  for i = 0 to len1 - 1
-  do
+  for i = 0 to len1 - 1 do
     let i = i * 4 in
     let v = string_unsafe_get_uint32 v i in
     unsafe_set_uint32 res i v
-  done ;
+  done
 
-  for i = 0 to len0 - 1
-  do
-    let i = len1 * 4 + i in
-    let v = string_unsafe_get_uint8 v i in
-    unsafe_set_uint8 res i v
-  done ; res
+  ; for i = 0 to len0 - 1 do
+      let i = (len1 * 4) + i in
+      let v = string_unsafe_get_uint8 v i in
+      unsafe_set_uint8 res i v
+    done
+  ; res
 
 let w = make_window ~bits:15
 let src = bigstring_create io_buffer_size
 let dst = bigstring_create io_buffer_size
 let q = Queue.create 4096
 let wrkmem = Lzo.make_wrkmem ()
-
 let unsafe_get_uint8 b i = Char.code (Bigstringaf.get b i)
 let unsafe_get_uint32_be b i = Bigstringaf.get_int32_be b i
 
 let pp_chr =
   Fmt.using (function '\032' .. '\126' as x -> x | _ -> '.') Fmt.char
 
-let pp_scalar : type buffer.
+let pp_scalar :
+    type buffer.
     get:(buffer -> int -> char) -> length:(buffer -> int) -> buffer Fmt.t =
  fun ~get ~length ppf b ->
   let l = length b in
   for i = 0 to l / 16 do
-    Fmt.pf ppf "%08x: " (i * 16) ;
-    let j = ref 0 in
-    while !j < 16 do
-      if (i * 16) + !j < l then
-        Fmt.pf ppf "%02x" (Char.code @@ get b ((i * 16) + !j))
-      else Fmt.pf ppf "  " ;
-      if !j mod 2 <> 0 then Fmt.pf ppf " " ;
-      incr j
-    done ;
-    Fmt.pf ppf "  " ;
-    j := 0 ;
-    while !j < 16 do
-      if (i * 16) + !j < l then Fmt.pf ppf "%a" pp_chr (get b ((i * 16) + !j))
-      else Fmt.pf ppf " " ;
-      incr j
-    done ;
-    Fmt.pf ppf "@\n"
+    Fmt.pf ppf "%08x: " (i * 16)
+    ; let j = ref 0 in
+      while !j < 16 do
+        if (i * 16) + !j < l then
+          Fmt.pf ppf "%02x" (Char.code @@ get b ((i * 16) + !j))
+        else Fmt.pf ppf "  "
+        ; if !j mod 2 <> 0 then Fmt.pf ppf " "
+        ; incr j
+      done
+      ; Fmt.pf ppf "  "
+      ; j := 0
+      ; while !j < 16 do
+          if (i * 16) + !j < l then
+            Fmt.pf ppf "%a" pp_chr (get b ((i * 16) + !j))
+          else Fmt.pf ppf " "
+          ; incr j
+        done
+      ; Fmt.pf ppf "@\n"
   done
 
 let pp_string = pp_scalar ~get:String.get ~length:String.length
-
 let str = Alcotest.testable pp_string String.equal
 
 let decode =
@@ -93,375 +99,433 @@ let decode =
     | _ -> false in
   Alcotest.testable pp equal
 
-let decode_i =
-  function
-  | Ok (v, _) -> v
-  | Error (_, (v, _)) -> v
-
-let decode_o =
-  function
-  | Ok (_, v) -> v
-  | Error _ -> raise Alcotest.Test_error
+let decode_i = function Ok (v, _) -> v | Error (_, (v, _)) -> v
+let decode_o = function Ok (_, v) -> v | Error _ -> raise Alcotest.Test_error
 
 let encode ~block:kind lst =
   let res = Buffer.create 16 in
   let q = Queue.of_list lst in
   let encoder = Def.encoder (`Buffer res) ~q in
-  match Def.encode encoder (`Block { kind; last= true; }) with
+  match Def.encode encoder (`Block {kind; last= true}) with
   | `Block -> assert false
   | `Partial -> assert false
-  | `Ok -> match Def.encode encoder `Flush with
+  | `Ok -> (
+    match Def.encode encoder `Flush with
     | `Ok -> Buffer.contents res
     | `Block -> Alcotest.fail "Bad block"
-    | `Partial -> assert false
+    | `Partial -> assert false)
 
 let encode_dynamic lst =
   let literals = make_literals () in
   let distances = make_distances () in
   List.iter
     (function
-     | `Literal chr -> succ_literal literals chr
-     | `Copy (off, len) ->
-        succ_length literals len ;
-        succ_distance distances off
-     | _ -> ())
-    lst ;
-  let dynamic = Def.dynamic_of_frequencies ~literals ~distances in
-  encode ~block:(Def.Dynamic dynamic) lst
+      | `Literal chr -> succ_literal literals chr
+      | `Copy (off, len) ->
+        succ_length literals len
+        ; succ_distance distances off
+      | _ -> ())
+    lst
+  ; let dynamic = Def.dynamic_of_frequencies ~literals ~distances in
+    encode ~block:(Def.Dynamic dynamic) lst
 
 let invalid_complement_of_length () =
   Alcotest.test_case "invalid complement of length" `Quick @@ fun () ->
   let src = bigstring_of_string "\x00\x00\x00\x00\x00" in
-  Alcotest.(check decode) "invalid complement of length"
-    (Error Invalid_complement_of_length)
+  Alcotest.(check decode)
+    "invalid complement of length" (Error Invalid_complement_of_length)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_kind_of_block () =
   Alcotest.test_case "invalid kind of block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x06" in
-  Alcotest.(check decode) "invalid kind of block"
-    (Error Invalid_kind_of_block)
+  Alcotest.(check decode)
+    "invalid kind of block" (Error Invalid_kind_of_block)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_code_lengths () =
   Alcotest.test_case "invalid code lengths" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\xfe\xff" in
-  Alcotest.(check decode) "invalid code lengths"
-    (Error Invalid_dictionary)
+  Alcotest.(check decode)
+    "invalid code lengths" (Error Invalid_dictionary)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_bit_length_repeat () =
   Alcotest.test_case "invalid bit length repeat" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\x24\x49\x00" in
-  Alcotest.(check decode) "invalid bit length repeat"
-    (Error Invalid_dictionary)
+  Alcotest.(check decode)
+    "invalid bit length repeat" (Error Invalid_dictionary)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_codes () =
   Alcotest.test_case "invalid codes -- missing end-of-block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\x24\xe9\xff\x6d" in
-  Alcotest.(check decode) "invalid codes -- missing end-of-block"
-    (Error Invalid_dictionary)
+  Alcotest.(check decode)
+    "invalid codes -- missing end-of-block" (Error Invalid_dictionary)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_lengths () =
   Alcotest.test_case "invalid literals/lengths" `Quick @@ fun () ->
-  let src = bigstring_of_string "\x04\x80\x49\x92\x24\x49\x92\x24\x49\x92\x24\x71\xff\xff\x93\x11\x00" in
-  Alcotest.(check decode) "invalid literals/lengths"
-    (Error Invalid_dictionary)
+  let src =
+    bigstring_of_string
+      "\x04\x80\x49\x92\x24\x49\x92\x24\x49\x92\x24\x71\xff\xff\x93\x11\x00"
+  in
+  Alcotest.(check decode)
+    "invalid literals/lengths" (Error Invalid_dictionary)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let invalid_distances () =
   Alcotest.test_case "invalid distances" `Quick @@ fun () ->
-  let src = bigstring_of_string "\x04\x80\x49\x92\x24\x49\x92\x24\x0f\xb4\xff\xff\xc3\x84" in
-  Alcotest.(check decode) "invalid distances"
-    (Error Invalid_dictionary)
+  let src =
+    bigstring_of_string
+      "\x04\x80\x49\x92\x24\x49\x92\x24\x0f\xb4\xff\xff\xc3\x84" in
+  Alcotest.(check decode)
+    "invalid distances" (Error Invalid_dictionary)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let too_many_length_or_distance_symbols () =
   Alcotest.test_case "too many length of distance symbols" `Quick @@ fun () ->
   let src = bigstring_of_string "\xfc\x00\x00" in
-  Alcotest.(check decode) "too many length of distance symbols"
-    (Error Unexpected_end_of_input)
+  Alcotest.(check decode)
+    "too many length of distance symbols" (Error Unexpected_end_of_input)
     (Inf.Ns.inflate ~src ~dst ~w)
+
 (* XXX(dinosaure): error is not conform to what we expect (best will be [Invalid
    dictionary]), TODO! *)
 
 let invalid_distance_code () =
   Alcotest.test_case "invalid distance code" `Quick @@ fun () ->
   let src = bigstring_of_string "\x02\x7e\xff\xff" in
-  Alcotest.(check decode) "invalid distance code"
-    (Error Invalid_distance_code)
-    (Inf.Ns.inflate ~src ~dst ~ w)
+  Alcotest.(check decode)
+    "invalid distance code" (Error Invalid_distance_code)
+    (Inf.Ns.inflate ~src ~dst ~w)
 
 (* XXX(dinosaure): see [Inf.base_dist]'s comment about this behavior. *)
 
 let invalid_distance_too_far_back () =
   Alcotest.test_case "invalid distance too far back" `Quick @@ fun () ->
-  let src = bigstring_of_string "\x0c\xc0\x81\x00\x00\x00\x00\x00\x90\xff\x6b\x04\x00" in
-  Alcotest.(check decode) "invalid distance too far back"
-    (Error Invalid_distance)
+  let src =
+    bigstring_of_string "\x0c\xc0\x81\x00\x00\x00\x00\x00\x90\xff\x6b\x04\x00"
+  in
+  Alcotest.(check decode)
+    "invalid distance too far back" (Error Invalid_distance)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let fixed () =
   Alcotest.test_case "fixed" `Quick @@ fun () ->
   let src = bigstring_of_string "\x03\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "" in
-  Alcotest.(check decode) "fixed"
+  Alcotest.(check decode)
+    "fixed"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "empty"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "empty" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let stored () =
   Alcotest.test_case "stored" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x01\x00\xfe\xff\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "\x00" in
-  Alcotest.(check decode) "stored"
+  Alcotest.(check decode)
+    "stored"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "0x00"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "0x00" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let length_extra () =
   Alcotest.test_case "length extra" `Quick @@ fun () ->
-  let src = bigstring_of_string "\xed\xc0\x01\x01\x00\x00\x00\x40\x20\xff\x57\x1b\x42\x2c\x4f" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string
+      "\xed\xc0\x01\x01\x00\x00\x00\x40\x20\xff\x57\x1b\x42\x2c\x4f" in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = String.make 516 '\x00' in
-  Alcotest.(check decode) "length extra"
+  Alcotest.(check decode)
+    "length extra"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "0x00 * 516"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "0x00 * 516" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let long_distance_and_extra () =
   Alcotest.test_case "long distance and extra" `Quick @@ fun () ->
-  let src = bigstring_of_string "\xed\xcf\xc1\xb1\x2c\x47\x10\xc4\x30\xfa\x6f\x35\x1d\x01\x82\x59\x3d\xfb\
-                                      \xbe\x2e\x2a\xfc\x0f\x0c" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string
+      "\xed\xcf\xc1\xb1\x2c\x47\x10\xc4\x30\xfa\x6f\x35\x1d\x01\x82\x59\x3d\xfb\xbe\x2e\x2a\xfc\x0f\x0c"
+  in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = String.make 518 '\x00' in
-  Alcotest.(check decode) "long distance and extra"
+  Alcotest.(check decode)
+    "long distance and extra"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "0x00 * 518"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "0x00 * 518" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let window_end () =
   Alcotest.test_case "window end" `Quick @@ fun () ->
-  let src = bigstring_of_string "\xed\xc0\x81\x00\x00\x00\x00\x80\xa0\xfd\xa9\x17\xa9\x00\x00\x00\x00\x00\
-                                      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
-                                      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x06" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string
+      "\xed\xc0\x81\x00\x00\x00\x00\x80\xa0\xfd\xa9\x17\xa9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06"
+  in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = String.make 33025 '\x00' in
-  Alcotest.(check decode) "window end"
+  Alcotest.(check decode)
+    "window end"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "0x00 * 33025"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "0x00 * 33025" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let flat_of_string () =
   Alcotest.test_case "flat of string" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x00\x00\xff\xff" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "" in
-  Alcotest.(check decode) "flat of string"
+  Alcotest.(check decode)
+    "flat of string"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "empty"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "empty" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let flat_block () =
   Alcotest.test_case "flat block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "\xde\xad\xbe\xef" in
-  Alcotest.(check decode) "flat block"
+  Alcotest.(check decode)
+    "flat block"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "deadbeef"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "deadbeef" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let huffman_length_extra () =
   Alcotest.test_case "huffman length extra" `Quick @@ fun () ->
   let literals = make_literals () in
-  succ_literal literals '\000' ;
-  succ_literal literals '\000' ;
-  succ_length literals 258 ;
-  succ_length literals 256 ;
-  let distances = make_distances () in
-  succ_distance distances 1 ;
-  succ_distance distances 1 ;
-  let dynamic = Def.dynamic_of_frequencies ~literals ~distances in
-  let res = encode ~block:(Def.Dynamic dynamic) [ `Literal '\000'
-                                                ; `Literal '\000'
-                                                ; `Copy (1, 258)
-                                                ; `Copy (1, 256)
-                                                ; `End ] in
-  Alcotest.(check str) "encoding" res "\237\193\001\001\000\000\000@ \255W\027B\193\234\004" ;
+  succ_literal literals '\000'
+  ; succ_literal literals '\000'
+  ; succ_length literals 258
+  ; succ_length literals 256
+  ; let distances = make_distances () in
+    succ_distance distances 1
+    ; succ_distance distances 1
+    ; let dynamic = Def.dynamic_of_frequencies ~literals ~distances in
+      let res =
+        encode ~block:(Def.Dynamic dynamic)
+          [
+            `Literal '\000'; `Literal '\000'; `Copy (1, 258); `Copy (1, 256)
+          ; `End
+          ] in
+      Alcotest.(check str)
+        "encoding" res "\237\193\001\001\000\000\000@ \255W\027B\193\234\004"
 
-  let src = bigstring_of_string res in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
-  let expected = String.make (258 + 256 + 2) '\000' in
-  Alcotest.(check decode) "huffman length extra"
-    (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check str) "result"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+      ; let src = bigstring_of_string res in
+        let res = Inf.Ns.inflate ~src ~dst ~w in
+        let expected = String.make (258 + 256 + 2) '\000' in
+        Alcotest.(check decode)
+          "huffman length extra"
+          (Ok (De.bigstring_length src, String.length expected))
+          res
+        ; Alcotest.(check str)
+            "result" expected
+            (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
-let ( <.> ) f g = fun x -> f (g x)
+let ( <.> ) f g x = f (g x)
 
 let dynamic_and_fixed () =
   Alcotest.test_case "dynamic+fixed" `Quick @@ fun () ->
   let res = Buffer.create 16 in
   let literals = make_literals () in
   let distances = make_distances () in
-  Queue.reset q ;
-  List.iter (Queue.push_exn q <.> Queue.cmd) [ `Literal 'a'; `Copy (1, 3) ] ;
-  succ_literal literals 'a' ;
-  succ_length literals 3 ;
-  succ_distance distances 1 ;
-  let dynamic_a = Def.dynamic_of_frequencies ~literals ~distances in
-  let encoder = Def.encoder (`Buffer res) ~q in
-  let rec go = function
-    | [] -> ()
-    | `Fill lst :: r ->
-      Alcotest.(check bool) "empty queue" (Queue.is_empty q) true ;
-      List.iter (Queue.push_exn q <.> Queue.cmd) lst ; go r
-    | #Def.encode as x :: r -> match Def.encode encoder x with
-      | `Partial -> Alcotest.fail "Impossible `Partial case"
-      | `Block -> Alcotest.fail "Impossible `Block case"
-      | `Ok -> go r in
-  go [ `Block { Def.kind= Def.Dynamic dynamic_a; Def.last= false; }
-     ; `Flush
-     ; `Fill [ `Literal 'b'; `Copy (1, 3); `End ]
-     ; `Block { Def.kind= Def.Fixed; Def.last= true; }
-     ; `Flush ] ;
-  let src = bigstring_of_string (Buffer.contents res) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
-  let expected = "aaaabbbb" in
-  Alcotest.(check decode) "dynamic+fixed"
-    (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check str) "result"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+  Queue.reset q
+  ; List.iter (Queue.push_exn q <.> Queue.cmd) [`Literal 'a'; `Copy (1, 3)]
+  ; succ_literal literals 'a'
+  ; succ_length literals 3
+  ; succ_distance distances 1
+  ; let dynamic_a = Def.dynamic_of_frequencies ~literals ~distances in
+    let encoder = Def.encoder (`Buffer res) ~q in
+    let rec go = function
+      | [] -> ()
+      | `Fill lst :: r ->
+        Alcotest.(check bool) "empty queue" (Queue.is_empty q) true
+        ; List.iter (Queue.push_exn q <.> Queue.cmd) lst
+        ; go r
+      | (#Def.encode as x) :: r -> (
+        match Def.encode encoder x with
+        | `Partial -> Alcotest.fail "Impossible `Partial case"
+        | `Block -> Alcotest.fail "Impossible `Block case"
+        | `Ok -> go r) in
+    go
+      [
+        `Block {Def.kind= Def.Dynamic dynamic_a; Def.last= false}; `Flush
+      ; `Fill [`Literal 'b'; `Copy (1, 3); `End]
+      ; `Block {Def.kind= Def.Fixed; Def.last= true}; `Flush
+      ]
+    ; let src = bigstring_of_string (Buffer.contents res) in
+      let res = Inf.Ns.inflate ~src ~dst ~w in
+      let expected = "aaaabbbb" in
+      Alcotest.(check decode)
+        "dynamic+fixed"
+        (Ok (De.bigstring_length src, String.length expected))
+        res
+      ; Alcotest.(check str)
+          "result" expected
+          (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fixed_and_dynamic () =
   Alcotest.test_case "fixed+dynamic" `Quick @@ fun () ->
   let res = Buffer.create 16 in
   let literals = make_literals () in
   let distances = make_distances () in
-  Queue.reset q ;
-  List.iter (Queue.push_exn q <.> Queue.cmd) [ `Literal 'a'; `Copy (1, 3) ] ;
-  succ_literal literals 'b' ;
-  succ_length literals 3 ;
-  succ_distance distances 1 ;
-  let dynamic_b = Def.dynamic_of_frequencies ~literals ~distances in
-  let encoder = Def.encoder (`Buffer res) ~q in
-  let rec go = function
-    | [] -> ()
-    | `Fill lst :: r ->
-      Alcotest.(check bool) "empty queue" (Queue.is_empty q) true ;
-      List.iter (Queue.push_exn q <.> Queue.cmd) lst ; go r
-    | #Def.encode as x :: r -> match Def.encode encoder x with
-      | `Partial -> Alcotest.fail "Impossible `Partial case"
-      | `Block -> Alcotest.fail "Impossible `Block case"
-      | `Ok -> go r in
-  go [ `Flush
-     ; `Block { Def.kind= Def.Dynamic dynamic_b; last= true; }
-     ; `Fill [ `Literal 'b'; `Copy (1, 3); `End ]
-     ; `Flush ] ;
-  Fmt.epr "> %S.\n%!" (Buffer.contents res) ;
-  let src = bigstring_of_string (Buffer.contents res) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
-  let expected = "aaaabbbb" in
-  Alcotest.(check decode) "fixed+dynamic"
-    (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check str) "result"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+  Queue.reset q
+  ; List.iter (Queue.push_exn q <.> Queue.cmd) [`Literal 'a'; `Copy (1, 3)]
+  ; succ_literal literals 'b'
+  ; succ_length literals 3
+  ; succ_distance distances 1
+  ; let dynamic_b = Def.dynamic_of_frequencies ~literals ~distances in
+    let encoder = Def.encoder (`Buffer res) ~q in
+    let rec go = function
+      | [] -> ()
+      | `Fill lst :: r ->
+        Alcotest.(check bool) "empty queue" (Queue.is_empty q) true
+        ; List.iter (Queue.push_exn q <.> Queue.cmd) lst
+        ; go r
+      | (#Def.encode as x) :: r -> (
+        match Def.encode encoder x with
+        | `Partial -> Alcotest.fail "Impossible `Partial case"
+        | `Block -> Alcotest.fail "Impossible `Block case"
+        | `Ok -> go r) in
+    go
+      [
+        `Flush; `Block {Def.kind= Def.Dynamic dynamic_b; last= true}
+      ; `Fill [`Literal 'b'; `Copy (1, 3); `End]; `Flush
+      ]
+    ; Fmt.epr "> %S.\n%!" (Buffer.contents res)
+    ; let src = bigstring_of_string (Buffer.contents res) in
+      let res = Inf.Ns.inflate ~src ~dst ~w in
+      let expected = "aaaabbbb" in
+      Alcotest.(check decode)
+        "fixed+dynamic"
+        (Ok (De.bigstring_length src, String.length expected))
+        res
+      ; Alcotest.(check str)
+          "result" expected
+          (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let dynamic_and_dynamic () =
   Alcotest.test_case "dynamic+dynamic" `Quick @@ fun () ->
   let res = Buffer.create 16 in
   let literals = make_literals () in
   let distances = make_distances () in
-  Queue.reset q ;
-  List.iter (Queue.push_exn q <.> Queue.cmd) [ `Literal 'a'; `Copy (1, 3); `Literal 'b'; `Copy (1, 3); `End ] ;
+  Queue.reset q
+  ; List.iter
+      (Queue.push_exn q <.> Queue.cmd)
+      [`Literal 'a'; `Copy (1, 3); `Literal 'b'; `Copy (1, 3); `End]
 
-  succ_literal literals 'a' ;
-  succ_length literals 3 ;
-  succ_distance distances 1 ;
-  let dynamic_a = Def.dynamic_of_frequencies ~literals ~distances in
-  succ_literal literals 'b' ;
-  succ_length literals 3 ;
-  succ_distance distances 1 ;
-  let dynamic_b = Def.dynamic_of_frequencies ~literals ~distances in
+  ; succ_literal literals 'a'
+  ; succ_length literals 3
+  ; succ_distance distances 1
+  ; let dynamic_a = Def.dynamic_of_frequencies ~literals ~distances in
+    succ_literal literals 'b'
+    ; succ_length literals 3
+    ; succ_distance distances 1
+    ; let dynamic_b = Def.dynamic_of_frequencies ~literals ~distances in
 
-  let encoder = Def.encoder (`Buffer res) ~q in
-  let rec go = function
-    | [] -> ()
-    | x :: `Block block :: r ->
-      ( match Def.encode encoder x with
-        | `Partial -> Alcotest.fail "Impossible `Partial case"
-        | `Block -> go ((`Block block) :: r)
-        | `Ok -> Alcotest.fail "Unexpected `Ok case" )
-    | x :: r -> match Def.encode encoder x with
-      | `Ok -> go r
-      | `Partial -> Alcotest.fail "Impossible `Partial case"
-      | `Block -> Alcotest.fail "Impossible `Block case" in
-  go [ `Block { Def.kind= Def.Dynamic dynamic_a; Def.last= false; }
-     ; `Block { Def.kind= Def.Dynamic dynamic_b; Def.last= true; }
-     ; `Flush ] ;
+      let encoder = Def.encoder (`Buffer res) ~q in
+      let rec go = function
+        | [] -> ()
+        | x :: `Block block :: r -> (
+          match Def.encode encoder x with
+          | `Partial -> Alcotest.fail "Impossible `Partial case"
+          | `Block -> go (`Block block :: r)
+          | `Ok -> Alcotest.fail "Unexpected `Ok case")
+        | x :: r -> (
+          match Def.encode encoder x with
+          | `Ok -> go r
+          | `Partial -> Alcotest.fail "Impossible `Partial case"
+          | `Block -> Alcotest.fail "Impossible `Block case") in
+      go
+        [
+          `Block {Def.kind= Def.Dynamic dynamic_a; Def.last= false}
+        ; `Block {Def.kind= Def.Dynamic dynamic_b; Def.last= true}; `Flush
+        ]
 
-  Fmt.epr "> %S.\n%!" (Buffer.contents res) ;
-  let src = bigstring_of_string (Buffer.contents res) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
-  let expected = "aaaabbbb" in
-  Alcotest.(check decode) "dynamic+dynamic"
-    (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check str) "result"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+      ; Fmt.epr "> %S.\n%!" (Buffer.contents res)
+      ; let src = bigstring_of_string (Buffer.contents res) in
+        let res = Inf.Ns.inflate ~src ~dst ~w in
+        let expected = "aaaabbbb" in
+        Alcotest.(check decode)
+          "dynamic+dynamic"
+          (Ok (De.bigstring_length src, String.length expected))
+          res
+        ; Alcotest.(check str)
+            "result" expected
+            (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let max_flat () =
   Alcotest.test_case "biggest flat block" `Quick @@ fun () ->
   let inputs = Bytes.make (0xFFFF + 1 + 4) '\x00' in
-  Bytes.set inputs 0 '\x01' ; (* last *)
-  Bytes.set inputs 1 '\xff' ; Bytes.set inputs 2 '\xff' ; (* len *)
-  let src = bigstring_of_string (Bytes.unsafe_to_string inputs) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
-  let expected = String.make 0xffff '\x00' in
-  Alcotest.(check decode) "biggest flat block"
-    (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "0xffff * \x00"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+  Bytes.set inputs 0 '\x01'
+  ; (* last *)
+    Bytes.set inputs 1 '\xff'
+  ; Bytes.set inputs 2 '\xff'
+  ; (* len *)
+    let src = bigstring_of_string (Bytes.unsafe_to_string inputs) in
+    let res = Inf.Ns.inflate ~src ~dst ~w in
+    let expected = String.make 0xffff '\x00' in
+    Alcotest.(check decode)
+      "biggest flat block"
+      (Ok (De.bigstring_length src, String.length expected))
+      res
+    ; Alcotest.(check string)
+        "0xffff * \x00" expected
+        (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let flat () =
   Alcotest.test_case "encode flat" `Quick @@ fun () ->
-  let q = Queue.of_list [ `Literal '\xDE'; `Literal '\xAD'; `Literal '\xBE'; `Literal '\xEF' ] in
+  let q =
+    Queue.of_list
+      [`Literal '\xDE'; `Literal '\xAD'; `Literal '\xBE'; `Literal '\xEF'] in
   let b = Buffer.create 16 in
   let encoder = Def.encoder (`Buffer b) ~q in
 
   let go = function
     | `Ok -> Buffer.contents b
     | `Partial | `Block -> assert false in
-  let res0 = go (Def.encode encoder (`Block { Def.kind= Def.Flat 4; last= true; })) in
-  Alcotest.(check string) "deadbeef deflated" "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" res0 ;
-  let src = bigstring_of_string res0 in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
-  let expected = "\xde\xad\xbe\xef" in
-  Alcotest.(check decode) "encode flat"
-    (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "deadbeef"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+  let res0 =
+    go (Def.encode encoder (`Block {Def.kind= Def.Flat 4; last= true})) in
+  Alcotest.(check string)
+    "deadbeef deflated" "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" res0
+  ; let src = bigstring_of_string res0 in
+    let res = Inf.Ns.inflate ~src ~dst ~w in
+    let expected = "\xde\xad\xbe\xef" in
+    Alcotest.(check decode)
+      "encode flat"
+      (Ok (De.bigstring_length src, String.length expected))
+      res
+    ; Alcotest.(check string)
+        "deadbeef" expected
+        (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fixed_and_flat () =
   Alcotest.test_case "fixed+flat" `Quick @@ fun () ->
-  let q = Queue.of_list [ `Literal 'a'; `Copy (1, 3); `End; `Literal '\xDE'; `Literal '\xAD'; `Literal '\xBE'; `Literal '\xEF' ] in
+  let q =
+    Queue.of_list
+      [
+        `Literal 'a'; `Copy (1, 3); `End; `Literal '\xDE'; `Literal '\xAD'
+      ; `Literal '\xBE'; `Literal '\xEF'
+      ] in
   let b = Buffer.create 16 in
   let encoder = Def.encoder (`Buffer b) ~q in
 
@@ -469,20 +533,29 @@ let fixed_and_flat () =
     | `Ok -> Buffer.contents b
     | `Partial -> assert false
     | `Block ->
-      go (Def.encode encoder (`Block { Def.kind= Def.Flat (Queue.length q); last= true; })) in
+      go
+        (Def.encode encoder
+           (`Block {Def.kind= Def.Flat (Queue.length q); last= true})) in
   let res0 = go (Def.encode encoder `Flush) in
   let src = bigstring_of_string res0 in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "aaaa\xde\xad\xbe\xef" in
-  Alcotest.(check decode) "fixed+flat"
+  Alcotest.(check decode)
+    "fixed+flat"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "aaaadeadbeef"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "aaaadeadbeef" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let flat_and_fixed () =
   Alcotest.test_case "flat+fixed" `Quick @@ fun () ->
-  let q = Queue.of_list [ `Literal '\xDE'; `Literal '\xAD'; `Literal '\xBE'; `Literal '\xEF'; `Literal 'a'; `Copy (1, 3); `End ] in
+  let q =
+    Queue.of_list
+      [
+        `Literal '\xDE'; `Literal '\xAD'; `Literal '\xBE'; `Literal '\xEF'
+      ; `Literal 'a'; `Copy (1, 3); `End
+      ] in
   let b = Buffer.create 16 in
   let encoder = Def.encoder (`Buffer b) ~q in
 
@@ -490,356 +563,479 @@ let flat_and_fixed () =
     | `Ok -> Buffer.contents b
     | `Partial -> assert false
     | `Block ->
-      go (Def.encode encoder (`Block { Def.kind= Def.Fixed; last= true; })) in
-  let res0 = go (Def.encode encoder (`Block { Def.kind= Def.Flat 4; last= false; })) in
+      go (Def.encode encoder (`Block {Def.kind= Def.Fixed; last= true})) in
+  let res0 =
+    go (Def.encode encoder (`Block {Def.kind= Def.Flat 4; last= false})) in
 
   let src = bigstring_of_string res0 in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "\xde\xad\xbe\xefaaaa" in
-  Alcotest.(check decode) "flat+fixed"
+  Alcotest.(check decode)
+    "flat+fixed"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "deadbeefaaaa"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "deadbeefaaaa" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz0 () =
   Alcotest.test_case "fuzz0" `Quick @@ fun () ->
-  let src = bigstring_of_string "{\220\n s\017\027\211\\\006\211w\176`\142\2007\156oZBo\163\136\017\247\
-                                 \158\247\012e\241\234sn_$\210\223\017\213\138\147]\129M\137<\242\1867\021\
-                                 c\194\156\135\194\167-wo\006\200\198" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string
+      "{\220\n\
+      \ \
+       s\017\027\211\\\006\211w\176`\142\2007\156oZBo\163\136\017\247\158\247\012e\241\234sn_$\210\223\017\213\138\147]\129M\137<\242\1867\021c\194\156\135\194\167-wo\006\200\198"
+  in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "\xe3\x85" in
-  Alcotest.(check decode) "fuzz0"
-    (Ok (4, String.length expected))
-    res;
-  Alcotest.(check string) "0x00 * 33025"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+  Alcotest.(check decode) "fuzz0" (Ok (4, String.length expected)) res
+  ; Alcotest.(check string)
+      "0x00 * 33025" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz1 () =
   Alcotest.test_case "fuzz1" `Quick @@ fun () ->
   let src = bigstring_of_string "\019\208nO\200\189r\020\176" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "\016+\135`m\212\197" in
-  Alcotest.(check decode) "fuzz1"
+  Alcotest.(check decode)
+    "fuzz1"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz1"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz1" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz2 () =
   Alcotest.test_case "fuzz2" `Quick @@ fun () ->
-  let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x80\x51\x56\x3a\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string "\x93\x3a\x55\x47\x12\x80\x51\x56\x3a\x01\x00\x00" in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\x1a\xca\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e" (* ..~~~~~~~~~~~~~~ *)
-    ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e" (* ~~~~~~~~~~~~~~~~ *)
-    ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e" (* ~~~~~~~~~~~~~~~~ *)
-    ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x3a\x2c\x50"                     (* ~~~~~~~~:,P *)      ] in
+    [
+      "\x1a\xca\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e"
+      (* ..~~~~~~~~~~~~~~ *)
+    ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e"
+      (* ~~~~~~~~~~~~~~~~ *)
+    ; "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e"
+      (* ~~~~~~~~~~~~~~~~ *); "\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x3a\x2c\x50"
+      (* ~~~~~~~~:,P *)
+    ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz2"
+  Alcotest.(check decode)
+    "fuzz2"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz2"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz2" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz3 () =
   Alcotest.test_case "fuzz3" `Quick @@ fun () ->
-  let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x36\x0a\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x36\x0a\x01\x00\x00" in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a" (* ..~..~..~..~..~. *)
-    ; "\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca" (* .~..~..~..~..~.. *)
-    ; "\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e" (* ~..~..~..~..~..~ *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76" (* .v.v.v.v.v.v.v.v *)
-    ; "\xc8\x76\xc8\x76"                                                 (* .v.v *)             ] in
+    [
+      "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a"
+      (* ..~..~..~..~..~. *)
+    ; "\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca"
+      (* .~..~..~..~..~.. *)
+    ; "\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e"
+      (* ~..~..~..~..~..~ *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *)
+    ; "\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76\xc8\x76"
+      (* .v.v.v.v.v.v.v.v *); "\xc8\x76\xc8\x76" (* .v.v *)
+    ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz3"
+  Alcotest.(check decode)
+    "fuzz3"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz3"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz3" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz4 () =
   Alcotest.test_case "fuzz4" `Quick @@ fun () ->
-  let src = bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x56\x0a\x06\x80\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x56\x0a\x06\x80\x00" in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a" (* ..~..~..~..~..~. *)
-    ; "\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca" (* .~..~..~..~..~.. *)
-    ; "\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e" (* ~..~..~..~..~..~ *)
-    ; "\xc8\x76\x75\x75\x75\x75\x75\x75"                                 (* .vuuuuuu *)         ] in
+    [
+      "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a"
+      (* ..~..~..~..~..~. *)
+    ; "\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca"
+      (* .~..~..~..~..~.. *)
+    ; "\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e"
+      (* ~..~..~..~..~..~ *); "\xc8\x76\x75\x75\x75\x75\x75\x75" (* .vuuuuuu *)
+    ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz4"
+  Alcotest.(check decode)
+    "fuzz4"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz4"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz4" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz5 () =
   Alcotest.test_case "fuzz5" `Quick @@ fun () ->
   let src =
-    [ "\x93\x3a\x55\x01\x01\x01\x01\xe6\x01\x01\x01\x01\x01\x01\x01\x01" (* .:U............. *)
-    ; "\x01\x01\x01\x01\x01\x00\x00"                                     (* ....... *)          ] in
+    [
+      "\x93\x3a\x55\x01\x01\x01\x01\xe6\x01\x01\x01\x01\x01\x01\x01\x01"
+      (* .:U............. *); "\x01\x01\x01\x01\x01\x00\x00" (* ....... *)
+    ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\x1a\xca\x78\x78\x78\x78\x78\x78\x78\x50\x50\x37\x50\x50\x50\x50" (* ..xxxxxxxPP7PPPP *)
-    ; "\x50\x50\x50\x50\x50\x50\x50\x50\x50"                             (* PPPPPPPPP *)        ] in
+    [
+      "\x1a\xca\x78\x78\x78\x78\x78\x78\x78\x50\x50\x37\x50\x50\x50\x50"
+      (* ..xxxxxxxPP7PPPP *); "\x50\x50\x50\x50\x50\x50\x50\x50\x50"
+      (* PPPPPPPPP *)
+    ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz5"
+  Alcotest.(check decode)
+    "fuzz5"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz5"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz5" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz6 () =
   Alcotest.test_case "fuzz6" `Quick @@ fun () ->
-  let src = bigstring_of_string "\x93\x8c\x8c\x8c\x8c\x7b\x8c\x8c\x8c\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string "\x93\x8c\x8c\x8c\x8c\x7b\x8c\x8c\x8c\x01\x00\x00" in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\x19\x59\x59\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59" (* .YYY^.Y^.Y^.Y^.Y *)
-    ; "\x5e\xe3\x33"                                                     (* ^.3 *)              ] in
+    [
+      "\x19\x59\x59\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59"
+      (* .YYY^.Y^.Y^.Y^.Y *); "\x5e\xe3\x33" (* ^.3 *)
+    ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz6"
+  Alcotest.(check decode)
+    "fuzz6"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz6"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz6" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz7 () =
   Alcotest.test_case "fuzz7" `Quick @@ fun () ->
-  let src = bigstring_of_string "\x93\x3a\x55\x69\x12\x3a\x3f\x10\x08\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let src =
+    bigstring_of_string "\x93\x3a\x55\x69\x12\x3a\x3f\x10\x08\x01\x00\x00" in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "\x1a\xca\x79\x34\x55\x9f\x51\x9f\x51\x9f" in
-  Alcotest.(check decode) "fuzz7"
+  Alcotest.(check decode)
+    "fuzz7"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz7"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz7" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz8 () =
   Alcotest.test_case "fuzz8" `Quick @@ fun () ->
   let src = bigstring_of_string "\x7a\x37\x6d\x99\x13" in
-  Alcotest.(check decode) "fuzz8"
-    (Error Unexpected_end_of_input)
+  Alcotest.(check decode)
+    "fuzz8" (Error Unexpected_end_of_input)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let fuzz9 () =
   Alcotest.test_case "fuzz9" `Quick @@ fun () ->
   let src =
-    [ "\x9b\x01\x95\xfc\x51\xd2\xed\xc8\xce\xc8\xff\x80\x00\x00\x7f\xff" (* ....Q........... *)
-    ; "\x79\x2f\xe9\x51\x88\x7b\xb8\x2f\xef\xa5\x8c\xf8\xf1\xb6\xce\xc8" (* y/.Q.{./........ *)
-    ; "\xb8\xc8\xff\x2f\x00\x7f\x88\x7b\xbc"                             (* .../...{. *)        ] in
+    [
+      "\x9b\x01\x95\xfc\x51\xd2\xed\xc8\xce\xc8\xff\x80\x00\x00\x7f\xff"
+      (* ....Q........... *)
+    ; "\x79\x2f\xe9\x51\x88\x7b\xb8\x2f\xef\xa5\x8c\xf8\xf1\xb6\xce\xc8"
+      (* y/.Q.{./........ *); "\xb8\xc8\xff\x2f\x00\x7f\x88\x7b\xbc"
+      (* .../...{. *)
+    ] in
   let src = bigstring_of_string (String.concat "" src) in
-  Alcotest.(check decode) "fuzz9"
-    (Error Invalid_distance)
+  Alcotest.(check decode)
+    "fuzz9" (Error Invalid_distance)
     (Inf.Ns.inflate ~src ~dst ~w)
 
 let fuzz10 () =
   Alcotest.test_case "fuzz10" `Quick @@ fun () ->
   let lst =
-    [ `Literal (Char.chr 231); `Literal (Char.chr 60); `Literal (Char.chr 128)
-    ; `Copy (1, 19); `End ] in
+    [
+      `Literal (Char.chr 231); `Literal (Char.chr 60); `Literal (Char.chr 128)
+    ; `Copy (1, 19); `End
+    ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
-  Alcotest.(check decode) "fuzz10"
-    (Ok (De.bigstring_length src, 22))
-    res
+  let res = Inf.Ns.inflate ~src ~dst ~w in
+  Alcotest.(check decode) "fuzz10" (Ok (De.bigstring_length src, 22)) res
 
 let fuzz11 () =
   Alcotest.test_case "fuzz11" `Quick @@ fun () ->
   let lst =
-    [ `Literal (Char.chr 228)
-    ; `Literal (Char.chr 255)
-    ; `Copy (1, 130)
-    ; `End ] in
+    [`Literal (Char.chr 228); `Literal (Char.chr 255); `Copy (1, 130); `End]
+  in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "\228" ^ String.make 131 '\xff' in
-  Alcotest.(check decode) "fuzz11"
+  Alcotest.(check decode)
+    "fuzz11"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz11"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz11" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz12 () =
   Alcotest.test_case "fuzz12" `Quick @@ fun () ->
   let lst =
-    [ `Literal (Char.chr 71)
-    ; `Literal (Char.chr 0)
-    ; `Literal (Char.chr 255)
-    ; `Copy (2, 249)
-    ; `End ] in
+    [
+      `Literal (Char.chr 71); `Literal (Char.chr 0); `Literal (Char.chr 255)
+    ; `Copy (2, 249); `End
+    ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\x47\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* G............... *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ................ *)
-    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"                 (* ............ *)
+    [
+      "\x47\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* G............... *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
+      (* ................ *)
+    ; "\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00" (* ............ *)
     ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz12"
+  Alcotest.(check decode)
+    "fuzz12"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz12"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz12" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz13 () =
   Alcotest.test_case "fuzz13" `Quick @@ fun () ->
-  let src =
-    [ "\x9b\x0e\x02\x00"                                                 (* .... *)
-    ] in
+  let src = ["\x9b\x0e\x02\x00" (* .... *)] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = "\x97\x97\x97\x97\x97" in
-  Alcotest.(check decode) "fuzz13"
+  Alcotest.(check decode)
+    "fuzz13"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz13"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz13" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz14 () =
   Alcotest.test_case "fuzz14" `Quick @@ fun () ->
   let src =
-    [ "\x0b\xff\x7f\x0c\x0c\x8f\xcd\x0e\x02\x21\x64\x0c\x04\x73\xff\x80" (* .........!d..s.. *)
-    ; "\x20\x0c\x8f\x1c\x1c\x1c\x1c\x0c\x0c\x0c\x0c\x64\x1c\x7f\x0c\x0c" (*  ..........d.... *)
-    ; "\x8f\xcd\x0e\x02\x21\xff\xff\x80"                                 (* ....!... *)
+    [
+      "\x0b\xff\x7f\x0c\x0c\x8f\xcd\x0e\x02\x21\x64\x0c\x04\x73\xff\x80"
+      (* .........!d..s.. *)
+    ; "\x20\x0c\x8f\x1c\x1c\x1c\x1c\x0c\x0c\x0c\x0c\x64\x1c\x7f\x0c\x0c"
+      (*  ..........d.... *); "\x8f\xcd\x0e\x02\x21\xff\xff\x80" (* ....!... *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\x57\xff\xc6\xff\xc6\xff\xc6\xff\xc6\x9b\x52\xc6\x9b\x52\xc6\xc6" (* W.........R..R.. *)
-    ; "\x9b\x52\xc6\xc6\x9b\x52\xc6\xc6\x9b\x52\xc6\xc6\xc6\xc6\x9d\xfc" (* .R...R...R...... *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc" (* ................ *)
-    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x53\x53\x53\x9b\x52\xc6\x9b\x52\xc6\x9b" (* ......SSS.R..R.. *)
-    ; "\x52\xc6\x9b\x52\xc6\x9b\x52\xc6\x9b\x52\xc6\x9b\x52\x33\x5f\xc6" (* R..R..R..R..R3_. *)
-    ; "\x5f\xc6\x5f\xc6\x5f\xc6\x9b\x52\xc6\x9b\x52\xc6\x4f\xff"         (* _._._..R..R.O. *)
+    [
+      "\x57\xff\xc6\xff\xc6\xff\xc6\xff\xc6\x9b\x52\xc6\x9b\x52\xc6\xc6"
+      (* W.........R..R.. *)
+    ; "\x9b\x52\xc6\xc6\x9b\x52\xc6\xc6\x9b\x52\xc6\xc6\xc6\xc6\x9d\xfc"
+      (* .R...R...R...... *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc\x9d\xfc"
+      (* ................ *)
+    ; "\x9d\xfc\x9d\xfc\x9d\xfc\x53\x53\x53\x9b\x52\xc6\x9b\x52\xc6\x9b"
+      (* ......SSS.R..R.. *)
+    ; "\x52\xc6\x9b\x52\xc6\x9b\x52\xc6\x9b\x52\xc6\x9b\x52\x33\x5f\xc6"
+      (* R..R..R..R..R3_. *)
+    ; "\x5f\xc6\x5f\xc6\x5f\xc6\x9b\x52\xc6\x9b\x52\xc6\x4f\xff"
+      (* _._._..R..R.O. *)
     ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz14"
+  Alcotest.(check decode)
+    "fuzz14"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz14"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz14" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz15 () =
   Alcotest.test_case "fuzz15" `Quick @@ fun () ->
   let src =
-    [ "\x75\x85\xcd\x0e\x02\x21\x0c\x84\x3d\xf3\x14\x3d\xc2\x65\x63\xb2" (* u....!..=..=.ec. *)
-    ; "\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12\xe4\xe9\x5d\xa3\x28\x26" (* .d.i....X...].(& *)
-    ; "\xee\xad\xc2\x65\x63\xb2\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12" (* ...ec..d.i....X. *)
-    ; "\xe4\xe9\x5d\x66\xfb\xe8\x57\x57\x18\xf3\x5b\xdd\xcb\x73"         (* ..]f..WW..[..s *)
+    [
+      "\x75\x85\xcd\x0e\x02\x21\x0c\x84\x3d\xf3\x14\x3d\xc2\x65\x63\xb2"
+      (* u....!..=..=.ec. *)
+    ; "\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12\xe4\xe9\x5d\xa3\x28\x26"
+      (* .d.i....X...].(& *)
+    ; "\xee\xad\xc2\x65\x63\xb2\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12"
+      (* ...ec..d.i....X. *)
+    ; "\xe4\xe9\x5d\x66\xfb\xe8\x57\x57\x18\xf3\x5b\xdd\xcb\x73"
+      (* ..]f..WW..[..s *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
-  let expected =
-    [ "\x78\x20\x5f\x74\x6c\x69\x63"                                     (* x _tlic *)
-    ] in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let expected = ["\x78\x20\x5f\x74\x6c\x69\x63" (* x _tlic *)] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz15"
-    (Ok (40, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz15"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+  Alcotest.(check decode) "fuzz15" (Ok (40, String.length expected)) res
+  ; Alcotest.(check string)
+      "fuzz15" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz16 () =
   Alcotest.test_case "fuzz16" `Quick @@ fun () ->
-  let lst = [ `Literal '@'
-            ; `Copy (1, 212)
-            ; `Copy (129, 258)
-            ; `Copy (7, 131)
-            ; `Copy (527, 208)
-            ; `Copy (129, 258)
-            ; `End ] in
+  let lst =
+    [
+      `Literal '@'; `Copy (1, 212); `Copy (129, 258); `Copy (7, 131)
+    ; `Copy (527, 208); `Copy (129, 258); `End
+    ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected = String.make 1068 '@' in
-  Alcotest.(check decode) "fuzz16"
+  Alcotest.(check decode)
+    "fuzz16"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz16"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz16" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz17 () =
   Alcotest.test_case "fuzz17" `Quick @@ fun () ->
-  let lst = [ `Literal (Char.chr 218); `Copy (1, 21); `Literal (Char.chr 190); `Literal (Char.chr 218); `Literal (Char.chr 0); `End ] in
+  let lst =
+    [
+      `Literal (Char.chr 218); `Copy (1, 21); `Literal (Char.chr 190)
+    ; `Literal (Char.chr 218); `Literal (Char.chr 0); `End
+    ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda" (* ................ *)
-    ; "\xda\xda\xda\xda\xda\xda\xbe\xda\x00"                             (* ......... *)
+    [
+      "\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda"
+      (* ................ *)
+    ; "\xda\xda\xda\xda\xda\xda\xbe\xda\x00" (* ......... *)
     ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz17"
+  Alcotest.(check decode)
+    "fuzz17"
     (Ok (De.bigstring_length src, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz17"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+    res
+  ; Alcotest.(check string)
+      "fuzz17" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let fuzz18 () =
   Alcotest.test_case "fuzz18" `Quick @@ fun () ->
   let src =
-    [ "\x75\x8f\xcd\x0e\x02\x21\x0c\x84\x3d\xf3\x14\x3d\xfc\x54\x63\xb2" (* u....!..=..=.Tc. *)
-    ; "\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12\xe4\xe9\x5d\xa3\x28\x26" (* .d.i....X...].(& *)
-    ; "\xee\xad\x33\xcd\xfc\x9d\x1a\x5e\x1e\xcc\xe7\xf9\x24\x99\x40\x06" (* ..3....^....$.@. *)
-    ; "\xed\x11\x4c\x56\xfb\xe8\x57\x57\x0a\xf3\x5b\xd9\xcb\x60\xd5\xd5" (* ..LV..WW..[..`.. *)
+    [
+      "\x75\x8f\xcd\x0e\x02\x21\x0c\x84\x3d\xf3\x14\x3d\xfc\x54\x63\xb2"
+      (* u....!..=..=.Tc. *)
+    ; "\x0f\x64\xf8\x69\xdc\xc6\xc2\x12\x58\x12\xe4\xe9\x5d\xa3\x28\x26"
+      (* .d.i....X...].(& *)
+    ; "\xee\xad\x33\xcd\xfc\x9d\x1a\x5e\x1e\xcc\xe7\xf9\x24\x99\x40\x06"
+      (* ..3....^....$.@. *)
+    ; "\xed\x11\x4c\x56\xfb\xe8\x57\x57\x0a\xf3\x5b\xd9\xcb\x60\xd5\xd5"
+      (* ..LV..WW..[..`.. *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~ w in
+  let res = Inf.Ns.inflate ~src ~dst ~w in
   let expected =
-    [ "\x75\x27\x5a\xfb\x64\x64\x2b\x63\x29\x67\x6e\x60\x20\x67\x6e\x60" (* u'dd+c)gn` gn` *)
-    ; "\x20\x67\x6e\x60\x5e\x28\x20\x5d\x6e\x0a\x63\x29\x67\x6e\x60\x20" (*  gn`^( ]n.c)gn`  *)
-    ; "\x67\x6e\x60\x20\x67\x6e\x63\x29\x67\x6e\x60\x20\x67\x73\x60\x69" (* gn` gnc)gn` gs`i *)
-    ; "\x63"                                                             (* c *)
+    [
+      "\x75\x27\x5a\xfb\x64\x64\x2b\x63\x29\x67\x6e\x60\x20\x67\x6e\x60"
+      (* u'dd+c)gn` gn` *)
+    ; "\x20\x67\x6e\x60\x5e\x28\x20\x5d\x6e\x0a\x63\x29\x67\x6e\x60\x20"
+      (*  gn`^( ]n.c)gn`  *)
+    ; "\x67\x6e\x60\x20\x67\x6e\x63\x29\x67\x6e\x60\x20\x67\x73\x60\x69"
+      (* gn` gnc)gn` gs`i *); "\x63" (* c *)
     ] in
   let expected = String.concat "" expected in
-  Alcotest.(check decode) "fuzz18"
-    (Ok (60, String.length expected))
-    res;
-  Alcotest.(check string) "fuzz18"
-    expected (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
+  Alcotest.(check decode) "fuzz18" (Ok (60, String.length expected)) res
+  ; Alcotest.(check string)
+      "fuzz18" expected
+      (Bigstringaf.substring dst ~off:0 ~len:(decode_o res))
 
 let w0 = make_window ~bits:15
 let w1 = make_window ~bits:15
@@ -849,45 +1045,48 @@ let q = Queue.create (2 * 2 * 4096)
 let b = Buffer.create 4096
 
 let compress_and_uncompress ic =
-  Buffer.clear b;
-  Queue.reset q ;
-  let refill input =
-    let len = min (in_channel_length ic - (pos_in ic)) io_buffer_size in
-    for i = 0 to len - 1
-    do
-      let v = Char.code (input_char ic) in
-      unsafe_set_uint8 input i v
-    done ;
-    len
-  in
-  let flush output l =
-    for i = 0 to l - 1
-    do Buffer.add_char b (Char.unsafe_chr (unsafe_get_uint8 output i)) done ;
-  in
+  Buffer.clear b
+  ; Queue.reset q
+  ; let refill input =
+      let len = min (in_channel_length ic - pos_in ic) io_buffer_size in
+      for i = 0 to len - 1 do
+        let v = Char.code (input_char ic) in
+        unsafe_set_uint8 input i v
+      done
+      ; len in
+    let flush output l =
+      for i = 0 to l - 1 do
+        Buffer.add_char b (Char.unsafe_chr (unsafe_get_uint8 output i))
+      done in
 
-  Higher.compress ~w:w0 ~q ~i ~o ~refill ~flush;
+    Higher.compress ~w:w0 ~q ~refill ~flush i o
 
-  let src = bigstring_of_string (Bytes.to_string (Buffer.to_bytes b)) in
-  let dst = bigstring_create (in_channel_length ic) in
+    ; let src = bigstring_of_string (Bytes.to_string (Buffer.to_bytes b)) in
+      let dst = bigstring_create (in_channel_length ic) in
 
-  match Inf.Ns.inflate ~src ~dst ~w:w1 with
-  | Ok (_, l) ->
-    Stdlib.seek_in ic 0 ;
-    Buffer.clear b;
-    for i = 0 to l - 1
-    do Buffer.add_char b (Char.unsafe_chr (unsafe_get_uint8 dst i)) done ;
-    let contents = Buffer.contents b in
-    let rec slow_compare pos =
-      match input_char ic with
-      | chr ->
-        if pos >= String.length contents then Fmt.invalid_arg "Reach end of contents" ;
-        if contents.[pos] <> chr
-        then Fmt.invalid_arg "Contents differ at %08x\n%!" pos ; slow_compare (succ pos)
-      | exception End_of_file ->
-        if pos <> String.length contents
-        then Fmt.invalid_arg "Lengths differ: (contents: %d, file: %d)" (String.length contents) pos in
-    slow_compare 0
-  | Error err -> Alcotest.failf "Error when inflating: %a" Inf.Ns.pp_error err
+      match Inf.Ns.inflate ~src ~dst ~w:w1 with
+      | Ok (_, l) ->
+        Stdlib.seek_in ic 0
+        ; Buffer.clear b
+        ; for i = 0 to l - 1 do
+            Buffer.add_char b (Char.unsafe_chr (unsafe_get_uint8 dst i))
+          done
+        ; let contents = Buffer.contents b in
+          let rec slow_compare pos =
+            match input_char ic with
+            | chr ->
+              if pos >= String.length contents then
+                Fmt.invalid_arg "Reach end of contents"
+              ; if contents.[pos] <> chr then
+                  Fmt.invalid_arg "Contents differ at %08x\n%!" pos
+              ; slow_compare (succ pos)
+            | exception End_of_file ->
+              if pos <> String.length contents then
+                Fmt.invalid_arg "Lengths differ: (contents: %d, file: %d)"
+                  (String.length contents) pos in
+          slow_compare 0
+      | Error err ->
+        Alcotest.failf "Error when inflating: %a" Inf.Ns.pp_error err
 
 let test_corpus filename =
   Alcotest.test_case filename `Slow @@ fun () ->
@@ -895,62 +1094,35 @@ let test_corpus filename =
   compress_and_uncompress ic ; close_in ic
 
 let tests =
-  [ "ns_invalids", [ invalid_complement_of_length ()
-                   ; invalid_kind_of_block ()
-                   ; invalid_code_lengths ()
-                   ; invalid_bit_length_repeat ()
-                   ; invalid_codes ()
-                   ; invalid_lengths ()
-                   ; invalid_distances ()
-                   ; too_many_length_or_distance_symbols ()
-                   ; invalid_distance_code ()
-                   ; invalid_distance_too_far_back () ]
-  ; "ns_valids", [ fixed ()
-                 ; stored ()
-                 ; length_extra ()
-                 ; long_distance_and_extra ()
-                 ; window_end ()
-                 ; huffman_length_extra ()
-                 ; dynamic_and_fixed ()
-                 ; fixed_and_dynamic ()
-                 ; dynamic_and_dynamic ()
-                 ; flat_of_string ()
-                 ; flat_block ()
-                 ; flat ()
-                 ; max_flat ()
-                 ; fixed_and_flat ()
-                 ; flat_and_fixed () ]
-  ; "ns_fuzz", [ fuzz0 ()
-               ; fuzz1 ()
-               ; fuzz2 ()
-               ; fuzz3 ()
-               ; fuzz4 ()
-               ; fuzz5 ()
-               ; fuzz6 ()
-               ; fuzz7 ()
-               ; fuzz8 ()
-               ; fuzz9 ()
-               ; fuzz10 ()
-               ; fuzz11 ()
-               ; fuzz12 ()
-               ; fuzz13 ()
-               ; fuzz14 ()
-               ; fuzz15 ()
-               ; fuzz16 ()
-               ; fuzz17 ()
-               ; fuzz18 () ]
-  ; "ns_calgary", [ test_corpus "bib"
-                  ; test_corpus "rfc5322.txt"
-                  ; test_corpus "book1"
-                  ; test_corpus "book2"
-                  ; test_corpus "geo"
-                  ; test_corpus "news"
-                  ; test_corpus "obj1"
-                  ; test_corpus "obj2"
-                  ; test_corpus "paper1"
-                  ; test_corpus "paper2"
-                  ; test_corpus "pic"
-                  ; test_corpus "progc"
-                  ; test_corpus "progl"
-                  ; test_corpus "progp"
-                  ; test_corpus "trans" ] ]
+  [
+    ( "ns_invalids"
+    , [
+        invalid_complement_of_length (); invalid_kind_of_block ()
+      ; invalid_code_lengths (); invalid_bit_length_repeat (); invalid_codes ()
+      ; invalid_lengths (); invalid_distances ()
+      ; too_many_length_or_distance_symbols (); invalid_distance_code ()
+      ; invalid_distance_too_far_back ()
+      ] )
+  ; ( "ns_valids"
+    , [
+        fixed (); stored (); length_extra (); long_distance_and_extra ()
+      ; window_end (); huffman_length_extra (); dynamic_and_fixed ()
+      ; fixed_and_dynamic (); dynamic_and_dynamic (); flat_of_string ()
+      ; flat_block (); flat (); max_flat (); fixed_and_flat ()
+      ; flat_and_fixed ()
+      ] )
+  ; ( "ns_fuzz"
+    , [
+        fuzz0 (); fuzz1 (); fuzz2 (); fuzz3 (); fuzz4 (); fuzz5 (); fuzz6 ()
+      ; fuzz7 (); fuzz8 (); fuzz9 (); fuzz10 (); fuzz11 (); fuzz12 (); fuzz13 ()
+      ; fuzz14 (); fuzz15 (); fuzz16 (); fuzz17 (); fuzz18 ()
+      ] )
+  ; ( "ns_calgary"
+    , [
+        test_corpus "bib"; test_corpus "rfc5322.txt"; test_corpus "book1"
+      ; test_corpus "book2"; test_corpus "geo"; test_corpus "news"
+      ; test_corpus "obj1"; test_corpus "obj2"; test_corpus "paper1"
+      ; test_corpus "paper2"; test_corpus "pic"; test_corpus "progc"
+      ; test_corpus "progl"; test_corpus "progp"; test_corpus "trans"
+      ] )
+  ]

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -1099,7 +1099,7 @@ let compress_and_uncompress ic =
       | Error err ->
         Alcotest.failf "Error when inflating: %a" Def.Ns.pp_error err
 
-        let zlib_compress_and_uncompress ic =
+let zlib_compress_and_uncompress ic =
   Buffer.clear b
   ; Queue.reset q
   ; let in_len = in_channel_length ic in
@@ -1221,8 +1221,6 @@ let tests =
       ] )
   ; ( "ns_zlib"
     , [
-        (* test_empty_with_zlib (); test_empty_with_zlib_and_small_output ()
-           ; test_empty_with_zlib_byte_per_byte () *)
         test_corpus_with_zlib "bib"; test_corpus_with_zlib "book1"
       ; test_corpus_with_zlib "book2"; test_corpus_with_zlib "geo"
       ; test_corpus_with_zlib "news"; test_corpus_with_zlib "obj1"
@@ -1230,6 +1228,5 @@ let tests =
       ; test_corpus_with_zlib "paper2"; test_corpus_with_zlib "pic"
       ; test_corpus_with_zlib "progc"; test_corpus_with_zlib "progl"
       ; test_corpus_with_zlib "progp"; test_corpus_with_zlib "trans"
-        (* ; test_multiple_flush_zlib () *)
       ] )
   ]

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -88,7 +88,7 @@ let decode =
       ~error:Inf.Ns.pp_error in
   let equal r1 r2 =
     match r1, r2 with
-    | Ok (i1, o1), Ok (i2, o2) -> Int.equal i1 i2 && Int.equal o1 o2
+    | Ok (i1, o1), Ok (i2, o2) -> i1 == i2 && o1 == o2
     | Error e1, Error e2 -> e1 == e2
     | _ -> false in
   Alcotest.testable pp equal

--- a/test/test_ns.ml
+++ b/test/test_ns.ml
@@ -134,35 +134,34 @@ let invalid_complement_of_length () =
   let src = bigstring_of_string "\x00\x00\x00\x00\x00" in
   Alcotest.(check decode)
     "invalid complement of length" (Error Invalid_complement_of_length)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst)
 
 let invalid_kind_of_block () =
   Alcotest.test_case "invalid kind of block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x06" in
   Alcotest.(check decode)
     "invalid kind of block" (Error Invalid_kind_of_block)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst)
 
 let invalid_code_lengths () =
   Alcotest.test_case "invalid code lengths" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\xfe\xff" in
   Alcotest.(check decode)
-    "invalid code lengths" (Error Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    "invalid code lengths" (Error Invalid_dictionary) (Inf.Ns.inflate ~src ~dst)
 
 let invalid_bit_length_repeat () =
   Alcotest.test_case "invalid bit length repeat" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\x24\x49\x00" in
   Alcotest.(check decode)
     "invalid bit length repeat" (Error Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst)
 
 let invalid_codes () =
   Alcotest.test_case "invalid codes -- missing end-of-block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x04\x00\x24\xe9\xff\x6d" in
   Alcotest.(check decode)
     "invalid codes -- missing end-of-block" (Error Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst)
 
 let invalid_lengths () =
   Alcotest.test_case "invalid literals/lengths" `Quick @@ fun () ->
@@ -172,7 +171,7 @@ let invalid_lengths () =
   in
   Alcotest.(check decode)
     "invalid literals/lengths" (Error Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst)
 
 let invalid_distances () =
   Alcotest.test_case "invalid distances" `Quick @@ fun () ->
@@ -180,15 +179,14 @@ let invalid_distances () =
     bigstring_of_string
       "\x04\x80\x49\x92\x24\x49\x92\x24\x0f\xb4\xff\xff\xc3\x84" in
   Alcotest.(check decode)
-    "invalid distances" (Error Invalid_dictionary)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    "invalid distances" (Error Invalid_dictionary) (Inf.Ns.inflate ~src ~dst)
 
 let too_many_length_or_distance_symbols () =
   Alcotest.test_case "too many length of distance symbols" `Quick @@ fun () ->
   let src = bigstring_of_string "\xfc\x00\x00" in
   Alcotest.(check decode)
     "too many length of distance symbols" (Error Unexpected_end_of_input)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst)
 
 (* XXX(dinosaure): error is not conform to what we expect (best will be [Invalid
    dictionary]), TODO! *)
@@ -198,7 +196,7 @@ let invalid_distance_code () =
   let src = bigstring_of_string "\x02\x7e\xff\xff" in
   Alcotest.(check decode)
     "invalid distance code" (Error Invalid_distance_code)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst)
 
 (* XXX(dinosaure): see [Inf.base_dist]'s comment about this behavior. *)
 
@@ -209,12 +207,12 @@ let invalid_distance_too_far_back () =
   in
   Alcotest.(check decode)
     "invalid distance too far back" (Error Invalid_distance)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    (Inf.Ns.inflate ~src ~dst)
 
 let fixed () =
   Alcotest.test_case "fixed" `Quick @@ fun () ->
   let src = bigstring_of_string "\x03\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "" in
   Alcotest.(check decode)
     "fixed"
@@ -227,7 +225,7 @@ let fixed () =
 let stored () =
   Alcotest.test_case "stored" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x01\x00\xfe\xff\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "\x00" in
   Alcotest.(check decode)
     "stored"
@@ -242,7 +240,7 @@ let length_extra () =
   let src =
     bigstring_of_string
       "\xed\xc0\x01\x01\x00\x00\x00\x40\x20\xff\x57\x1b\x42\x2c\x4f" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = String.make 516 '\x00' in
   Alcotest.(check decode)
     "length extra"
@@ -258,7 +256,7 @@ let long_distance_and_extra () =
     bigstring_of_string
       "\xed\xcf\xc1\xb1\x2c\x47\x10\xc4\x30\xfa\x6f\x35\x1d\x01\x82\x59\x3d\xfb\xbe\x2e\x2a\xfc\x0f\x0c"
   in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = String.make 518 '\x00' in
   Alcotest.(check decode)
     "long distance and extra"
@@ -274,7 +272,7 @@ let window_end () =
     bigstring_of_string
       "\xed\xc0\x81\x00\x00\x00\x00\x80\xa0\xfd\xa9\x17\xa9\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06"
   in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = String.make 33025 '\x00' in
   Alcotest.(check decode)
     "window end"
@@ -287,7 +285,7 @@ let window_end () =
 let flat_of_string () =
   Alcotest.test_case "flat of string" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x00\x00\xff\xff" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "" in
   Alcotest.(check decode)
     "flat of string"
@@ -300,7 +298,7 @@ let flat_of_string () =
 let flat_block () =
   Alcotest.test_case "flat block" `Quick @@ fun () ->
   let src = bigstring_of_string "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "\xde\xad\xbe\xef" in
   Alcotest.(check decode)
     "flat block"
@@ -331,7 +329,7 @@ let huffman_length_extra () =
         "encoding" res "\237\193\001\001\000\000\000@ \255W\027B\193\234\004"
 
       ; let src = bigstring_of_string res in
-        let res = Inf.Ns.inflate ~src ~dst ~w in
+        let res = Inf.Ns.inflate ~src ~dst in
         let expected = String.make (258 + 256 + 2) '\000' in
         Alcotest.(check decode)
           "huffman length extra"
@@ -373,7 +371,7 @@ let dynamic_and_fixed () =
       ; `Block {Def.kind= Def.Fixed; Def.last= true}; `Flush
       ]
     ; let src = bigstring_of_string (Buffer.contents res) in
-      let res = Inf.Ns.inflate ~src ~dst ~w in
+      let res = Inf.Ns.inflate ~src ~dst in
       let expected = "aaaabbbb" in
       Alcotest.(check decode)
         "dynamic+fixed"
@@ -413,7 +411,7 @@ let fixed_and_dynamic () =
       ]
     ; Fmt.epr "> %S.\n%!" (Buffer.contents res)
     ; let src = bigstring_of_string (Buffer.contents res) in
-      let res = Inf.Ns.inflate ~src ~dst ~w in
+      let res = Inf.Ns.inflate ~src ~dst in
       let expected = "aaaabbbb" in
       Alcotest.(check decode)
         "fixed+dynamic"
@@ -463,7 +461,7 @@ let dynamic_and_dynamic () =
 
       ; Fmt.epr "> %S.\n%!" (Buffer.contents res)
       ; let src = bigstring_of_string (Buffer.contents res) in
-        let res = Inf.Ns.inflate ~src ~dst ~w in
+        let res = Inf.Ns.inflate ~src ~dst in
         let expected = "aaaabbbb" in
         Alcotest.(check decode)
           "dynamic+dynamic"
@@ -482,7 +480,7 @@ let max_flat () =
   ; Bytes.set inputs 2 '\xff'
   ; (* len *)
     let src = bigstring_of_string (Bytes.unsafe_to_string inputs) in
-    let res = Inf.Ns.inflate ~src ~dst ~w in
+    let res = Inf.Ns.inflate ~src ~dst in
     let expected = String.make 0xffff '\x00' in
     Alcotest.(check decode)
       "biggest flat block"
@@ -508,7 +506,7 @@ let flat () =
   Alcotest.(check string)
     "deadbeef deflated" "\x01\x04\x00\xfb\xff\xde\xad\xbe\xef" res0
   ; let src = bigstring_of_string res0 in
-    let res = Inf.Ns.inflate ~src ~dst ~w in
+    let res = Inf.Ns.inflate ~src ~dst in
     let expected = "\xde\xad\xbe\xef" in
     Alcotest.(check decode)
       "encode flat"
@@ -538,7 +536,7 @@ let fixed_and_flat () =
            (`Block {Def.kind= Def.Flat (Queue.length q); last= true})) in
   let res0 = go (Def.encode encoder `Flush) in
   let src = bigstring_of_string res0 in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "aaaa\xde\xad\xbe\xef" in
   Alcotest.(check decode)
     "fixed+flat"
@@ -568,7 +566,7 @@ let flat_and_fixed () =
     go (Def.encode encoder (`Block {Def.kind= Def.Flat 4; last= false})) in
 
   let src = bigstring_of_string res0 in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "\xde\xad\xbe\xefaaaa" in
   Alcotest.(check decode)
     "flat+fixed"
@@ -586,7 +584,7 @@ let fuzz0 () =
       \ \
        s\017\027\211\\\006\211w\176`\142\2007\156oZBo\163\136\017\247\158\247\012e\241\234sn_$\210\223\017\213\138\147]\129M\137<\242\1867\021c\194\156\135\194\167-wo\006\200\198"
   in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "\xe3\x85" in
   Alcotest.(check decode) "fuzz0" (Ok (4, String.length expected)) res
   ; Alcotest.(check string)
@@ -596,7 +594,7 @@ let fuzz0 () =
 let fuzz1 () =
   Alcotest.test_case "fuzz1" `Quick @@ fun () ->
   let src = bigstring_of_string "\019\208nO\200\189r\020\176" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "\016+\135`m\212\197" in
   Alcotest.(check decode)
     "fuzz1"
@@ -610,7 +608,7 @@ let fuzz2 () =
   Alcotest.test_case "fuzz2" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x3a\x55\x47\x12\x80\x51\x56\x3a\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\x1a\xca\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e\x7e"
@@ -634,7 +632,7 @@ let fuzz3 () =
   Alcotest.test_case "fuzz3" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x36\x0a\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a"
@@ -689,7 +687,7 @@ let fuzz4 () =
   Alcotest.test_case "fuzz4" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x3a\x55\x47\x12\x3a\x51\x56\x0a\x06\x80\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a\xca\x7e\x1a"
@@ -716,7 +714,7 @@ let fuzz5 () =
       (* .:U............. *); "\x01\x01\x01\x01\x01\x00\x00" (* ....... *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\x1a\xca\x78\x78\x78\x78\x78\x78\x78\x50\x50\x37\x50\x50\x50\x50"
@@ -736,7 +734,7 @@ let fuzz6 () =
   Alcotest.test_case "fuzz6" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x8c\x8c\x8c\x8c\x7b\x8c\x8c\x8c\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\x19\x59\x59\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59\x5e\xe3\x59"
@@ -755,7 +753,7 @@ let fuzz7 () =
   Alcotest.test_case "fuzz7" `Quick @@ fun () ->
   let src =
     bigstring_of_string "\x93\x3a\x55\x69\x12\x3a\x3f\x10\x08\x01\x00\x00" in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "\x1a\xca\x79\x34\x55\x9f\x51\x9f\x51\x9f" in
   Alcotest.(check decode)
     "fuzz7"
@@ -769,8 +767,7 @@ let fuzz8 () =
   Alcotest.test_case "fuzz8" `Quick @@ fun () ->
   let src = bigstring_of_string "\x7a\x37\x6d\x99\x13" in
   Alcotest.(check decode)
-    "fuzz8" (Error Unexpected_end_of_input)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    "fuzz8" (Error Unexpected_end_of_input) (Inf.Ns.inflate ~src ~dst)
 
 let fuzz9 () =
   Alcotest.test_case "fuzz9" `Quick @@ fun () ->
@@ -784,8 +781,7 @@ let fuzz9 () =
     ] in
   let src = bigstring_of_string (String.concat "" src) in
   Alcotest.(check decode)
-    "fuzz9" (Error Invalid_distance)
-    (Inf.Ns.inflate ~src ~dst ~w)
+    "fuzz9" (Error Invalid_distance) (Inf.Ns.inflate ~src ~dst)
 
 let fuzz10 () =
   Alcotest.test_case "fuzz10" `Quick @@ fun () ->
@@ -795,7 +791,7 @@ let fuzz10 () =
     ; `Copy (1, 19); `End
     ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   Alcotest.(check decode) "fuzz10" (Ok (De.bigstring_length src, 22)) res
 
 let fuzz11 () =
@@ -804,7 +800,7 @@ let fuzz11 () =
     [`Literal (Char.chr 228); `Literal (Char.chr 255); `Copy (1, 130); `End]
   in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "\228" ^ String.make 131 '\xff' in
   Alcotest.(check decode)
     "fuzz11"
@@ -822,7 +818,7 @@ let fuzz12 () =
     ; `Copy (2, 249); `End
     ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\x47\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00\xff\x00"
@@ -870,7 +866,7 @@ let fuzz13 () =
   Alcotest.test_case "fuzz13" `Quick @@ fun () ->
   let src = ["\x9b\x0e\x02\x00" (* .... *)] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = "\x97\x97\x97\x97\x97" in
   Alcotest.(check decode)
     "fuzz13"
@@ -890,7 +886,7 @@ let fuzz14 () =
       (*  ..........d.... *); "\x8f\xcd\x0e\x02\x21\xff\xff\x80" (* ....!... *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\x57\xff\xc6\xff\xc6\xff\xc6\xff\xc6\x9b\x52\xc6\x9b\x52\xc6\xc6"
@@ -957,7 +953,7 @@ let fuzz15 () =
       (* ..]f..WW..[..s *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = ["\x78\x20\x5f\x74\x6c\x69\x63" (* x _tlic *)] in
   let expected = String.concat "" expected in
   Alcotest.(check decode) "fuzz15" (Ok (40, String.length expected)) res
@@ -973,7 +969,7 @@ let fuzz16 () =
     ; `Copy (527, 208); `Copy (129, 258); `End
     ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected = String.make 1068 '@' in
   Alcotest.(check decode)
     "fuzz16"
@@ -991,7 +987,7 @@ let fuzz17 () =
     ; `Literal (Char.chr 218); `Literal (Char.chr 0); `End
     ] in
   let src = bigstring_of_string (encode_dynamic lst) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda\xda"
@@ -1021,7 +1017,7 @@ let fuzz18 () =
       (* ..LV..WW..[..`.. *)
     ] in
   let src = bigstring_of_string (String.concat "" src) in
-  let res = Inf.Ns.inflate ~src ~dst ~w in
+  let res = Inf.Ns.inflate ~src ~dst in
   let expected =
     [
       "\x75\x27\x5a\xfb\x64\x64\x2b\x63\x29\x67\x6e\x60\x20\x67\x6e\x60"
@@ -1061,7 +1057,7 @@ let compress_and_uncompress ic =
       ; (* ignore (assert false); *)
         let src_inf = Bigstringaf.sub dst_def ~off:0 ~len in
         let dst_inf = bigstring_create (in_channel_length ic) in
-        match Inf.Ns.inflate ~src:src_inf ~dst:dst_inf ~w:w1 with
+        match Inf.Ns.inflate ~src:src_inf ~dst:dst_inf with
         | Ok (_, len) ->
           Stdlib.seek_in ic 0
           ; Buffer.clear b


### PR DESCRIPTION
This work is currently in progress. It aims to provide a non streamable implementation of the RFC 1951.
The main use should be an increase with the performances as we do not need to save the general state of the compression/decompression every time.
The drawback is that the user needs to provide the entire object to compress/decompress in one single time.

There might still be some artifacts of the streamable implementation but they should be cleaned and removed as the time goes by.

To do:
- [x] Inflation implemented
- [x] Inflation largely tested
- [x] Deflation implemented
- [x] Deflation largely tested
- [x] zlib wrapper adapted
- ~gzip wrapper adapted~
- [x] Rewrite a clean commit history