### PR TITLE
Fix unused arguments in Gz

### DIFF
--- a/lib/gz.ml
+++ b/lib/gz.ml
@@ -847,6 +847,8 @@ module Higher = struct
         ~ascii:configuration.ascii
         ~hcrc:configuration.hcrc
         ~mtime:(configuration.mtime time)
+	?filename
+	?comment
         configuration.os in
     let rec go encoder = match Def.encode encoder with
       | `Await encoder ->


### PR DESCRIPTION
This simple PR aims to make the use of two unconsidered arguments in `Gz.Higher.compress`. 