### PR TITLE
Be able to create a zlib/gzip document without compression

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.21.0
+version=0.22.4
 profile=conventional
 break-struct=natural
 break-infix=fit-or-vertical

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -103,6 +103,8 @@ let json =
   Arg.(value & flag & info ["j"; "json"] ~doc)
 
 let cmd =
-  Term.(const inflate $ max $ json), Term.info "bench" ~doc:"Run benchmarks"
+  Cmd.v
+    (Cmd.info "bench" ~doc:"Run benchmarks")
+    Term.(const inflate $ max $ json)
 
-let () = Term.(exit @@ eval cmd)
+let () = exit @@ Cmd.eval cmd

--- a/bench/run.ml
+++ b/bench/run.ml
@@ -33,5 +33,5 @@ let path =
 let output = Arg.(value & opt (some path) None & info ["o"])
 let max = Arg.(value & pos ~rev:true 0 int 30 & info [])
 let json = Arg.(value & flag & info ["j"; "json"])
-let cmd = Term.(const run $ output $ max $ json), Term.info "run"
-let () = Term.(exit @@ eval cmd)
+let cmd = Cmd.v (Cmd.info "run") Term.(const run $ output $ max $ json)
+let () = exit @@ Cmd.eval cmd

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -212,6 +212,10 @@ module Queue : sig
   val eob : cmd
   (** [eob] is {i End Of Block} {!cmd}.*)
 
+  val end_with_eob : t -> bool
+  (** [end_with_eob t] returns [true] if the last inserted command
+      is {!eob}. Otherwise, it returns [false]. *)
+
   val cmd : [ `Literal of char | `Copy of int * int | `End ] -> cmd
   (** [cmd command] is {!cmd} from a human-readable value. *)
 
@@ -278,7 +282,7 @@ module Def : sig
 
   (** The type for DEFLATE header block. *)
   type kind =
-    | Flat of int
+    | Flat
         (** A [Flat len] block is a non-compressed block of [len] byte(s). After a
        {i flat} block, output is aligned on bytes. *)
     | Fixed
@@ -465,6 +469,8 @@ module Lz77 : sig
       The client can constrain lookup operation by a {i window}. Small window
      enforces {!compress} to emit small distances. However, large window allows
      {!compress} to go furthermore to recognize a pattern which can be expensive. *)
+
+  val no_compression : state -> bool
 end
 
 (** {2 Higher API.}

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -4,9 +4,36 @@
    codec to {{:#decode}decode} and {{:#encode}encode} DEFLATE encoding. It can
    efficiently work payload by payload without blocking IO.
 
-    Module provides {{:#compression}LZ77 compression} algorithm but let the
-   client to define his algorithm as long as he uses shared queue provided in
-   this module. *)
+    Module provides {{:#compression}LZ77 compression} algorithm but lets the
+   client to define his algorithm as long as he/she uses shared queue provided
+   in this module.
+
+    {1 Lz77 compression and huffman compression.}
+
+    [Lz77] does a compression such as it searches a repeated {i pattern} and
+   emits a [Copy] code (see {!type:Queue.cmd}) which tells us to copy a
+   previous pattern. For instance, this is an equivalence between a list
+   of {!type:Queue.cmd}s and a [string].
+
+    {[
+      let cmds = [ `Literal 'a'; `Copy (1, 3) ]
+      let results = "aaaa"
+    ]}
+
+     The goal of [Lz77] is to produce such list from a [string] to help then
+    a format such as [DEFLATE] to compress inputs.
+
+     [Def] does an huffman compression. From a list of {!type:Queue.cmd}, it
+    can calculate frequencies (see {!type:literals} and {!type:distances}) and
+    generate a smaller representation of the given {i alphabet}. Such
+    compression is available {i via} the {!const:Def.Fixed} or the
+    {!const:Def.Dynamic} block. The {!const:Def.Flat} block does a copy of any
+    literals into the output.
+
+     {b NOTE}: It's illegal to emit a [`Copy] {!type:Queue.cmd} and try to
+    serialize it with a {!const:Def.Flat} block. {!Queue.eob} is {b required}
+    for {!const:Def.Fixed} and {!const:Def.Dynamic} (to delimit the end of the
+    block) and ignored by the {!const:Def.Flat} block. *)
 
 (** {2 Prelude.}
 
@@ -468,7 +495,18 @@ module Lz77 : sig
 
       The client can constrain lookup operation by a {i window}. Small window
      enforces {!compress} to emit small distances. However, large window allows
-     {!compress} to go furthermore to recognize a pattern which can be expensive. *)
+     {!compress} to go furthermore to recognize a pattern which can be expensive.
+
+      {b Level.}
+
+      [Lz77] has mainly 2 levels:
+      - [0] where we only copy inputs to outpus, we don't do a lookup
+      - [n] (to [9]) with a certain configuration of the lookup. The higher the
+        level, the longer it may take to find a pattern.
+
+      The [0] can be useful to {b only} {i pack} an input into a format such as
+      [DEFLATE] - as an already compressed document such as a video or an
+      image. Otherwise, [4] as the level is pretty common. *)
 
   val no_compression : state -> bool
 end

--- a/lib/gz.ml
+++ b/lib/gz.ml
@@ -722,7 +722,8 @@ module Def = struct
     if o_rem e >= 8 then k e else flush checksum e
 
   let make_block ?(last = false) e =
-    if last = false then
+    if De.Lz77.no_compression e.s then {De.Def.kind= Flat; last}
+    else if last = false then
       let literals = De.Lz77.literals e.s in
       let distances = De.Lz77.distances e.s in
       let dynamic = De.Def.dynamic_of_frequencies ~literals ~distances in

--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -498,7 +498,8 @@ module Def = struct
     if o_rem e >= 4 then k e else flush checksum e
 
   let make_block ?(last = false) e =
-    if last = false && e.dynamic then
+    if De.Lz77.no_compression e.s then {De.Def.kind= De.Def.Flat; last}
+    else if last = false && e.dynamic then
       let literals = De.Lz77.literals e.s in
       let distances = De.Lz77.distances e.s in
       let dynamic = De.Def.dynamic_of_frequencies ~literals ~distances in
@@ -574,7 +575,7 @@ module Def = struct
     ; o_pos
     ; o_len
     ; level=
-        (match level with 0 | 1 -> 0 | 2 | 3 | 4 | 5 -> 1 | 6 -> 2 | _ -> 3)
+        (match level with 0 -> 0 | 1 | 2 | 3 | 4 | 5 -> 1 | 6 -> 2 | _ -> 3)
     ; dynamic
     ; e= De.Def.encoder `Manual ~q
     ; s= De.Lz77.state ~level `Manual ~q ~w

--- a/test/bin/bindings.t
+++ b/test/bin/bindings.t
@@ -23,7 +23,7 @@ Test reverse bindings
   >   return (0);
   > }
   > EOF
-  $ cc -o a.out main.c -I$(ocamlopt -where) -L../../bindings/stubs -I../../bindings/stubs -ldecompress -lm -ldl
+  $ cc -o a.out main.c -I$(ocamlopt -where) -L../../bindings/stubs -I../../bindings/stubs -ldecompress -lm -ldl 2> /dev/null
   $ ./a.out
   Hello World!
 

--- a/test/bin/simple.t
+++ b/test/bin/simple.t
@@ -20,3 +20,9 @@ Simple tests
   $ decompress -fzlib -d ../corpus/bib bib.zlib
   $ decompress -fzlib bib.zlib bib
   $ diff bib ../corpus/bib
+  $ decompress -fzlib -d --level 0 ../corpus/bib bib.zlib
+  $ decompress -fzlib bib.zlib bib
+  $ diff bib ../corpus/bib
+  $ decompress -fgzip -d --level 0 ../corpus/news news.gz
+  $ decompress -fgzip news.gz news
+  $ diff news ../corpus/news

--- a/test/test_deflate.ml
+++ b/test/test_deflate.ml
@@ -107,7 +107,8 @@ let corpus =
 let () =
   Alcotest.run "lz"
     [
-      "1", List.map (deflate_with_level ~level:1) corpus
+      "0", List.map (deflate_with_level ~level:0) corpus
+    ; "1", List.map (deflate_with_level ~level:1) corpus
     ; "2", List.map (deflate_with_level ~level:2) corpus
     ; "3", List.map (deflate_with_level ~level:3) corpus
     ; "4", List.map (deflate_with_level ~level:4) corpus


### PR DESCRIPTION
This patch unlock the ability to create a `zlib`/`gzip` document without compression. It can be useful specially for video/image or any documents which are already compressed. This patch **breaks** the API  where the kind of block `Flat` does not requires anymore a size (in bytes).

The `Flat` block has a new - and more homogeneous - behavior than `Fixed` or `Dynamic`. Instead to asks the user to require bytes, it will just look up into the shared queue and emit `command` without huffman compression. However, we can apply an huffman compression even if the `Lz77` does not do any compression.

This big change is due to the internal loop of `Zl`/`Gz` which expects a certain sequence of instructions. Tests (only `deflate` tests) are modified as well to fit with this new behavior. The `level = 0` for `Zl`/`Gz` means **no compression now**! Be aware that you probably should increment the level if you uses `0` before. I will let this PR open to see implications on upper layers (specially for Git).