### PR TITLE
Remove remaining bits of bigarray-compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ memory.
  * OCaml >= 4.07.0
  * `dune` to build the project
  * `base-bytes` meta-package
- * `bigarray-compat`
  * `checkseum`
  * `optint`
 

--- a/bench/dune
+++ b/bench/dune
@@ -9,7 +9,6 @@
  (preprocess
   (pps ppx_deriving_yojson))
  (libraries
-  bigarray-compat
   unix
   fmt
   decompress.de
@@ -51,7 +50,7 @@
  (modules lz_landmarks)
  (enabled_if
   (= %{profile} benchmark))
- (libraries bigarray-compat checkseum optint landmarks de)
+ (libraries checkseum optint landmarks de)
  (preprocess
   (pps landmarks.ppx --auto)))
 
@@ -74,7 +73,7 @@
  (modules de_landmarks)
  (enabled_if
   (= %{profile} benchmark))
- (libraries bigarray-compat checkseum optint landmarks de)
+ (libraries checkseum optint landmarks de)
  (flags
   (:standard -w -55))
  (preprocess

--- a/bindings/stubs/dune
+++ b/bindings/stubs/dune
@@ -7,7 +7,7 @@
  (name gen_decompress_bindings)
  (modules gen_decompress_bindings)
  (wrapped false)
- (libraries bigarray-compat decompress.de decompress.zl ctypes.stubs))
+ (libraries decompress.de decompress.zl ctypes.stubs))
 
 (executable
  (name decompress)

--- a/test/dune
+++ b/test/dune
@@ -1,18 +1,7 @@
 (executable
  (name test)
  (modules test test_ns)
- (libraries
-  fmt
-  base64
-  camlzip
-  bigarray-compat
-  bigstringaf
-  checkseum.c
-  de
-  zl
-  gz
-  lzo
-  alcotest))
+ (libraries fmt base64 camlzip bigstringaf checkseum.c de zl gz lzo alcotest))
 
 (executable
  (name test_deflate)


### PR DESCRIPTION
Most of it was already removed in https://github.com/mirage/decompress/pull/138. I don't know why some references were left, but they seem to be unused.