### PR TITLE
Be able to dynamically choose the best block according to frequencies

### DIFF
--- a/lib/de.ml
+++ b/lib/de.ml
@@ -2341,6 +2341,42 @@ module Def = struct
   type block = {kind: kind; last: bool}
   type encode = [ `Await | `Flush | `Block of block ]
 
+  let calculate_static_block ~literals ~distances =
+    let bits = ref 0 in
+    for idx = 0 to _l_codes - 1 do
+      if literals.(idx) <> 0 then
+        bits := !bits + (literals.(idx) * fst (Lookup.get _static_ltree idx))
+    done
+    ; for idx = 0 to _d_codes - 1 do
+        if distances.(idx) <> 0 then
+          bits := !bits + (distances.(idx) + fst (Lookup.get _static_dtree idx))
+      done
+    ; !bits
+
+  let calculate_dynamic_block dynamic ~literals ~distances =
+    (* HLIT + HDST + HCLEN + precode lengths *)
+    let bits = ref (5 + 5 + 4 + (dynamic.h_len * 3)) in
+    let fn x = bits := !bits + (x lsr _max_bits) in
+    Array.iter fn dynamic.symbols
+    ; let ltree = dynamic.ltree.T.lengths and dtree = dynamic.dtree.T.lengths in
+      for idx = 0 to _l_codes - 1 do
+        if literals.(idx) <> 0 then
+          bits := !bits + (literals.(idx) * ltree.(idx))
+      done
+      ; for idx = 0 to _d_codes - 1 do
+          if distances.(idx) <> 0 then
+            bits := !bits + (distances.(idx) + dtree.(idx))
+        done
+      ; !bits
+
+  let block_of_frequencies ~last ~literals ~distances =
+    let dynamic = dynamic_of_frequencies ~literals ~distances in
+    if
+      calculate_dynamic_block dynamic ~literals ~distances
+      <= calculate_static_block ~literals ~distances
+    then {kind= Dynamic dynamic; last}
+    else {kind= Fixed; last}
+
   let exists v block =
     match v, block.kind with
     | (`Copy _ | `End), Flat ->
@@ -4442,20 +4478,19 @@ module Higher = struct
   let compress ~w ~q ~refill ~flush i o =
     let state = Lz77.state `Manual ~w ~q in
     let encoder = Def.encoder `Manual ~q in
-    let kind = ref Def.Fixed in
+
+    let block ~last =
+      let literals = Lz77.literals state in
+      let distances = Lz77.distances state in
+      Def.block_of_frequencies ~last ~literals ~distances in
 
     let rec compress () =
       match Lz77.compress state with
       | `Await ->
         let len = refill i in
         Lz77.src state i 0 len ; compress ()
-      | `Flush ->
-        let literals = Lz77.literals state in
-        let distances = Lz77.distances state in
-        kind := Def.Dynamic (Def.dynamic_of_frequencies ~literals ~distances)
-        ; encode (Def.encode encoder (`Block {Def.kind= !kind; last= false}))
-      | `End ->
-        pending (Def.encode encoder (`Block {Def.kind= Def.Fixed; last= true}))
+      | `Flush -> encode (Def.encode encoder (`Block (block ~last:false)))
+      | `End -> pending (Def.encode encoder (`Block (block ~last:true)))
     and encode = function
       | `Partial ->
         let len = bigstring_length o - Def.dst_rem encoder in
@@ -4463,11 +4498,7 @@ module Higher = struct
         ; Def.dst encoder o 0 (bigstring_length o)
         ; encode (Def.encode encoder `Await)
       | `Ok -> compress ()
-      | `Block ->
-        let literals = Lz77.literals state in
-        let distances = Lz77.distances state in
-        kind := Def.Dynamic (Def.dynamic_of_frequencies ~literals ~distances)
-        ; encode (Def.encode encoder (`Block {Def.kind= !kind; last= false}))
+      | `Block -> encode (Def.encode encoder (`Block (block ~last:false)))
     and pending = function
       | `Block -> assert false (* XXX(dinosaure): should never appear. *)
       | `Partial ->
@@ -4518,28 +4549,23 @@ module Higher = struct
     let buf = Buffer.create buffer in
     let state = Lz77.state `Manual ~q ~w in
     let encoder = Def.encoder (`Buffer buf) ~q in
-    let kind = ref Def.Fixed in
+
+    let block ~last =
+      let literals = Lz77.literals state in
+      let distances = Lz77.distances state in
+      Def.block_of_frequencies ~last ~literals ~distances in
 
     let rec compress () =
       match Lz77.compress state with
       | `Await ->
         let len = refill i in
         Lz77.src state i 0 len ; compress ()
-      | `Flush ->
-        let literals = Lz77.literals state in
-        let distances = Lz77.distances state in
-        kind := Def.Dynamic (Def.dynamic_of_frequencies ~literals ~distances)
-        ; encode (Def.encode encoder (`Block {Def.kind= !kind; last= false}))
-      | `End ->
-        pending (Def.encode encoder (`Block {Def.kind= Def.Fixed; last= true}))
+      | `Flush -> encode (Def.encode encoder (`Block (block ~last:false)))
+      | `End -> pending (Def.encode encoder (`Block (block ~last:true)))
     and encode = function
       | `Partial -> assert false
       | `Ok -> compress ()
-      | `Block ->
-        let literals = Lz77.literals state in
-        let distances = Lz77.distances state in
-        kind := Def.Dynamic (Def.dynamic_of_frequencies ~literals ~distances)
-        ; encode (Def.encode encoder (`Block {Def.kind= !kind; last= false}))
+      | `Block -> encode (Def.encode encoder (`Block (block ~last:false)))
     and pending = function `Partial | `Block -> assert false | `Ok -> () in
 
     Queue.reset q ; compress () ; Buffer.contents buf

--- a/lib/de.mli
+++ b/lib/de.mli
@@ -345,6 +345,17 @@ module Def : sig
       If all frequencies are upper than 0, resulted [dynamic] Huffman tree is
       able to encode any symbols. *)
 
+  val block_of_frequencies :
+    last:bool -> literals:literals -> distances:distances -> block
+  (** [block_of_frequencies ~last ~literals ~distances] is a {!block} whose
+      {!kind} is whichever a {!Fixed} (static Huffman trees) or a {!Dynamic}
+      (Huffman trees computed from the frequencies) block. It choose the block
+      header in the most compact way.
+
+      A dynamic block always pays for the description of its trees, so
+      [block_of_frequencies] falls back to a static block on small or very
+      uniform inputs where that overhead is not amortised. *)
+
   type encoder
   (** The type for DEFLATE encoders. *)
 

--- a/lib/gz.ml
+++ b/lib/gz.ml
@@ -653,6 +653,7 @@ module Def = struct
     ; e: De.Def.encoder
     ; w: De.Lz77.window
     ; state: state
+    ; first: bool
     ; flg: int
     ; xfl: int
     ; os: int
@@ -722,12 +723,10 @@ module Def = struct
 
   let make_block ?(last = false) e =
     if De.Lz77.no_compression e.s then {De.Def.kind= Flat; last}
-    else if last = false then
+    else
       let literals = De.Lz77.literals e.s in
       let distances = De.Lz77.distances e.s in
-      let dynamic = De.Def.dynamic_of_frequencies ~literals ~distances in
-      {De.Def.kind= De.Def.Dynamic dynamic; last}
-    else {De.Def.kind= De.Def.Fixed; last}
+      De.Def.block_of_frequencies ~last ~literals ~distances
 
   let zero_terminated str kfinal e =
     let pos = ref 0 in
@@ -819,6 +818,9 @@ module Def = struct
         | `Await ->
           refill compress
             {e with i_pos= e.i_pos + (i_rem e - De.Lz77.src_rem e.s)}
+        | `Flush when e.first ->
+          encode_deflate {e with first= false}
+            (De.Def.encode e.e (`Block (make_block e)))
         | `Flush -> encode_deflate e (De.Def.encode e.e `Flush)
         | `End ->
           let block = make_block ~last:true e in
@@ -903,6 +905,7 @@ module Def = struct
     ; q
     ; w
     ; state= Hd
+    ; first= true
     ; xfl
     ; flg
     ; mtime

--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -438,6 +438,7 @@ module Def = struct
     ; e: De.Def.encoder
     ; w: De.Lz77.window
     ; state: state
+    ; first: bool
     ; k: encoder -> [ `Await of encoder | `Flush of encoder | `End of encoder ]
   }
 
@@ -499,11 +500,10 @@ module Def = struct
 
   let make_block ?(last = false) e =
     if De.Lz77.no_compression e.s then {De.Def.kind= De.Def.Flat; last}
-    else if last = false && e.dynamic then
+    else if e.dynamic then
       let literals = De.Lz77.literals e.s in
       let distances = De.Lz77.distances e.s in
-      let dynamic = De.Def.dynamic_of_frequencies ~literals ~distances in
-      {De.Def.kind= De.Def.Dynamic dynamic; last}
+      De.Def.block_of_frequencies ~last ~literals ~distances
     else {De.Def.kind= De.Def.Fixed; last}
 
   let rec encode e =
@@ -527,6 +527,9 @@ module Def = struct
         | `Await ->
           refill compress
             {e with i_pos= e.i_pos + (i_rem e - De.Lz77.src_rem e.s)}
+        | `Flush when e.first ->
+          encode_deflate {e with first= false}
+            (De.Def.encode e.e (`Block (make_block e)))
         | `Flush -> encode_deflate e (De.Def.encode e.e `Flush)
         | `End ->
           let block = make_block ~last:true e in
@@ -582,6 +585,7 @@ module Def = struct
     ; q
     ; w
     ; state= Hd
+    ; first= true
     ; k= encode
     }
 


### PR DESCRIPTION
This commit improves a bit how we compress data. Before this commit, decompress only choose the Fixed block as the first one because, on some inputs, the Dynamic block has a real cost but it appears that in some situation, it's probably better to use the Dynamic block instead of the Fixed one (mostly when we have got enough inputs).

According to frequencies, we can approximate what will be the cost if we use a Fixed block or a Dynamic block. Then, we take the better one. With this patch, decompress does not start everytimes with a Fixed block now.

A new function block_of_frequencies is available which does this calculation. It is used by our zlib & gzip layer.