### PR TITLE
use warning name instead of number when disabling warnings

### DIFF
--- a/fuzz/fuzz_ns.ml
+++ b/fuzz/fuzz_ns.ml
@@ -54,7 +54,7 @@ let () =
   Bstr.blit_from_string input ~src_off:0 i ~dst_off:0 ~len
   ; let src_def = Bstr.sub i ~off:0 ~len in
     let res = Def.Ns.deflate src_def o in
-    let[@warning "-8"] (Ok res) = res in
+    let[@warning "-partial-match"] (Ok res) = res in
     let src_inf = Bstr.sub o ~off:0 ~len:res in
     let res = Inf.Ns.inflate src_inf i in
     match res with

--- a/lib/de.ml
+++ b/lib/de.ml
@@ -459,7 +459,7 @@ module WInf = struct
   let max = 1 lsl 15
   let mask = (1 lsl 15) - 1
 
-  let[@warning "-32"] make () =
+  let[@warning "-unused-value-declaration"] make () =
     {raw= bigstring_create max; w= 0; c= Checkseum.Adler32.default}
 
   let from raw = {raw; w= 0; c= Checkseum.Adler32.default}
@@ -1225,7 +1225,7 @@ module Inf = struct
     with Invalid_huffman -> err_invalid_dictionary d
 
   let inflate_table d =
-    let[@warning "-8"] (Inflate_table
+    let[@warning "-partial-match"] (Inflate_table
                           {t; l= max_bits; r= res; h= hlit, hdist, _}) =
       d.s in
     let max_res = hlit + hdist in
@@ -1279,7 +1279,7 @@ module Inf = struct
      have enough bytes to inflate huffman tree. *)
 
   let table d =
-    let[@warning "-8"] (Table {hlit; hdist; hclen}) = d.s in
+    let[@warning "-partial-match"] (Table {hlit; hdist; hclen}) = d.s in
     let hold = ref d.hold in
     let bits = ref d.bits in
     let t_pos = ref 0 in

--- a/lib/gz.ml
+++ b/lib/gz.ml
@@ -462,7 +462,7 @@ module Inf = struct
 
   let rec header d =
     let k d =
-      let[@warning "-8"] (Hd {o}) = d.dd in
+      let[@warning "-partial-match"] (Hd {o}) = d.dd in
 
       let kfinal d =
         let window = De.make_window ~bits:15 in

--- a/lib/zl.ml
+++ b/lib/zl.ml
@@ -246,7 +246,7 @@ module Inf = struct
 
   let rec header d =
     let k d =
-      let[@warning "-8"] (Hd {o}) = d.dd in
+      let[@warning "-partial-match"] (Hd {o}) = d.dd in
       let cmf = unsafe_get_uint16_le d.t 0 in
       let cm = cmf land 0b1111 in
       let cinfo = (cmf lsr 4) land 0b1111 in

--- a/test/test.ml
+++ b/test/test.ml
@@ -1468,9 +1468,9 @@ let git_object () =
     | `Malformed err -> failwith err
     | `End _ -> () in
   go decoder
-  ; let[@warning "-8"] (i0 :: i1) = inputs in
+  ; let[@warning "-partial-match"] (i0 :: i1) = inputs in
     let i1 = String.concat "" i1 in
-    let[@warning "-8"] [i0; i1] =
+    let[@warning "-partial-match"] [i0; i1] =
       List.map (fun x -> Bstr.string ~off:0 ~len:(String.length x) x) [i0; i1]
     in
     let decoder = Zl.Inf.decoder `Manual ~o ~allocate:(fun _ -> w) in


### PR DESCRIPTION
Thanks for your work on decompress. There's a tiny improvement for me eyes that I want to suggest: instead of using numbers for warnings, use the warning name.

What do you think? This feature is available since OCaml 4.12.0.